### PR TITLE
fix: Add missing Tailwind CSS and PostCSS configuration files

### DIFF
--- a/mana-meeples-shop/postcss.config.js
+++ b/mana-meeples-shop/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/mana-meeples-shop/tailwind.config.js
+++ b/mana-meeples-shop/tailwind.config.js
@@ -1,0 +1,52 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+    "./public/index.html"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: [
+          '-apple-system',
+          'BlinkMacSystemFont',
+          "'Segoe UI'",
+          "'Roboto'",
+          "'Oxygen'",
+          "'Ubuntu'",
+          "'Cantarell'",
+          "'Fira Sans'",
+          "'Droid Sans'",
+          "'Helvetica Neue'",
+          'sans-serif'
+        ],
+      },
+      spacing: {
+        '4': '4px',
+        '8': '8px',
+        '16': '16px',
+        '24': '24px',
+        '32': '32px',
+        '48': '48px'
+      },
+      colors: {
+        primary: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
+          400: '#60a5fa',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          800: '#1e40af',
+          900: '#1e3a8a',
+        },
+      },
+      animation: {
+        'spin': 'spin 1s linear infinite',
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
Fixes #34 - CSS all broken

The issue was that Tailwind CSS was installed and imported in `src/index.css` but the required configuration files were missing.

## Changes
- Added `tailwind.config.js` with proper content paths and theme configuration
- Added `postcss.config.js` to process Tailwind CSS
- Follows the project's design system from `docs/claude.md`

## Testing
All existing Tailwind classes in components should now render properly.

Generated with [Claude Code](https://claude.ai/code)