### PR TITLE
Fix admin login CORS issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -152,6 +152,10 @@ if (process.env.NODE_ENV === 'production' && process.env.RENDER_EXTERNAL_URL) {
   allowedOrigins.push(process.env.RENDER_EXTERNAL_URL);
 }
 
+// Always allow the production frontend domain
+allowedOrigins.push('https://manaandmeeples.co.nz');
+allowedOrigins.push('https://www.manaandmeeples.co.nz');
+
 app.use(cors({
   origin: (origin, callback) => {
     // Allow requests with no origin (mobile apps, Postman, curl, etc.)


### PR DESCRIPTION
Fixes #44

Added production frontend domains (manaandmeeples.co.nz) to CORS allowed origins.
This resolves the 401 Unauthorized error when the frontend tries to access the admin authentication endpoints.

Generated with [Claude Code](https://claude.ai/code)