### PR TITLE
Fix admin login cookie SameSite policy for cross-domain authentication

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -52,7 +52,7 @@ router.post('/admin/login', async (req, res) => {
     res.cookie('adminToken', token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax', // ✅ CHANGED
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax', // ✅ FIXED for cross-domain
       maxAge: 24 * 60 * 60 * 1000, // 24 hours
       path: '/' // ✅ ADDED - ensure cookie is available for all paths
     });


### PR DESCRIPTION
The issue was that cookies were set with sameSite: 'strict' in production,
which prevents cross-site cookie transmission between manaandmeeples.co.nz
(frontend) and mana-meeples-singles-market.onrender.com (API).

Changed to sameSite: 'none' in production to allow cross-domain cookies,
which is required for the admin authentication to work properly.

Generated with [Claude Code](https://claude.ai/code)