### PR TITLE
feat: eliminate zero-quantity database entries with dynamic inventory

### DIFF
--- a/database/migrations/add_card_pricing_table.sql
+++ b/database/migrations/add_card_pricing_table.sql
@@ -1,0 +1,72 @@
+-- Migration: Add card_pricing table to store base pricing without inventory entries
+-- This replaces the zero-quantity inventory entries created during import
+
+-- Create sequence for card_pricing table
+CREATE SEQUENCE IF NOT EXISTS card_pricing_id_seq;
+
+-- Create card_pricing table to store base pricing information
+CREATE TABLE "public"."card_pricing" (
+    "id" int4 NOT NULL DEFAULT nextval('card_pricing_id_seq'::regclass),
+    "card_id" int4 NOT NULL,
+    "base_price" numeric(10,2) NOT NULL DEFAULT 0,
+    "foil_price" numeric(10,2) NOT NULL DEFAULT 0,
+    "price_source" varchar(50) DEFAULT 'manual'::character varying,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create unique constraint on card_id (one pricing entry per card)
+ALTER TABLE "public"."card_pricing" ADD CONSTRAINT "card_pricing_card_id_key" UNIQUE ("card_id");
+
+-- Create foreign key constraint
+ALTER TABLE "public"."card_pricing" ADD CONSTRAINT "card_pricing_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "public"."cards"("id") ON DELETE CASCADE;
+
+-- Create indices for performance
+CREATE INDEX "idx_card_pricing_card_id" ON "public"."card_pricing" USING btree ("card_id");
+CREATE INDEX "idx_card_pricing_updated" ON "public"."card_pricing" USING btree ("updated_at" DESC);
+CREATE INDEX "idx_card_pricing_source" ON "public"."card_pricing" USING btree ("price_source");
+
+-- Create trigger to auto-update updated_at
+CREATE TRIGGER "update_card_pricing_updated_at"
+  BEFORE UPDATE ON "public"."card_pricing"
+  FOR EACH ROW
+  EXECUTE FUNCTION "public"."update_updated_at_column"();
+
+-- Migrate existing zero-quantity inventory pricing to card_pricing table
+-- This preserves the pricing data while removing the zero-stock entries
+INSERT INTO card_pricing (card_id, base_price, foil_price, price_source, updated_at)
+SELECT
+  ci.card_id,
+  -- Get base price from Regular/Non-foil Near Mint entry
+  (SELECT price FROM card_inventory ci_base
+   WHERE ci_base.card_id = ci.card_id
+   AND ci_base.quality = 'Near Mint'
+   AND (ci_base.foil_type = 'Regular' OR ci_base.foil_type = 'Non-foil')
+   LIMIT 1) as base_price,
+  -- Get foil price from Foil Near Mint entry, fallback to base price * 2.5
+  COALESCE(
+    (SELECT price FROM card_inventory ci_foil
+     WHERE ci_foil.card_id = ci.card_id
+     AND ci_foil.quality = 'Near Mint'
+     AND ci_foil.foil_type = 'Foil'
+     LIMIT 1),
+    (SELECT price * 2.5 FROM card_inventory ci_base
+     WHERE ci_base.card_id = ci.card_id
+     AND ci_base.quality = 'Near Mint'
+     AND (ci_base.foil_type = 'Regular' OR ci_base.foil_type = 'Non-foil')
+     LIMIT 1)
+  ) as foil_price,
+  ci.price_source,
+  NOW()
+FROM card_inventory ci
+WHERE ci.stock_quantity = 0
+  AND ci.quality = 'Near Mint'
+  AND (ci.foil_type = 'Regular' OR ci.foil_type = 'Non-foil')
+GROUP BY ci.card_id, ci.price_source
+ON CONFLICT (card_id) DO NOTHING;
+
+-- Clean up: Remove all zero-quantity inventory entries
+-- These are now replaced by the card_pricing table
+DELETE FROM card_inventory WHERE stock_quantity = 0;
+
+COMMIT;

--- a/scripts/migrate-card-pricing.js
+++ b/scripts/migrate-card-pricing.js
@@ -1,0 +1,140 @@
+const { Pool } = require('pg');
+require('dotenv').config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+async function migrateCardPricing() {
+  console.log('\n🔄 Starting card pricing migration...');
+  console.log('━'.repeat(60));
+
+  try {
+    // Create the card_pricing table
+    console.log('📋 Creating card_pricing table...');
+
+    await pool.query(`
+      -- Create sequence for card_pricing table
+      CREATE SEQUENCE IF NOT EXISTS card_pricing_id_seq;
+    `);
+
+    await pool.query(`
+      -- Create card_pricing table to store base pricing information
+      CREATE TABLE IF NOT EXISTS "public"."card_pricing" (
+          "id" int4 NOT NULL DEFAULT nextval('card_pricing_id_seq'::regclass),
+          "card_id" int4 NOT NULL,
+          "base_price" numeric(10,2) NOT NULL DEFAULT 0,
+          "foil_price" numeric(10,2) NOT NULL DEFAULT 0,
+          "price_source" varchar(50) DEFAULT 'manual'::character varying,
+          "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+          "created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+
+    // Create constraints and indices
+    console.log('🔧 Creating constraints and indices...');
+
+    try {
+      await pool.query(`
+        ALTER TABLE "public"."card_pricing" ADD CONSTRAINT "card_pricing_card_id_key" UNIQUE ("card_id");
+      `);
+    } catch (e) {
+      if (!e.message.includes('already exists')) {
+        throw e;
+      }
+    }
+
+    try {
+      await pool.query(`
+        ALTER TABLE "public"."card_pricing" ADD CONSTRAINT "card_pricing_card_id_fkey"
+        FOREIGN KEY ("card_id") REFERENCES "public"."cards"("id") ON DELETE CASCADE;
+      `);
+    } catch (e) {
+      if (!e.message.includes('already exists')) {
+        throw e;
+      }
+    }
+
+    // Create indices
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS "idx_card_pricing_card_id" ON "public"."card_pricing" USING btree ("card_id");
+      CREATE INDEX IF NOT EXISTS "idx_card_pricing_updated" ON "public"."card_pricing" USING btree ("updated_at" DESC);
+      CREATE INDEX IF NOT EXISTS "idx_card_pricing_source" ON "public"."card_pricing" USING btree ("price_source");
+    `);
+
+    // Migrate existing zero-quantity inventory pricing to card_pricing table
+    console.log('📦 Migrating existing pricing data...');
+
+    const migrationResult = await pool.query(`
+      INSERT INTO card_pricing (card_id, base_price, foil_price, price_source, updated_at)
+      SELECT
+        ci.card_id,
+        -- Get base price from Regular/Non-foil Near Mint entry
+        (SELECT price FROM card_inventory ci_base
+         WHERE ci_base.card_id = ci.card_id
+         AND ci_base.quality = 'Near Mint'
+         AND (ci_base.foil_type = 'Regular' OR ci_base.foil_type = 'Non-foil')
+         LIMIT 1) as base_price,
+        -- Get foil price from Foil Near Mint entry, fallback to base price * 2.5
+        COALESCE(
+          (SELECT price FROM card_inventory ci_foil
+           WHERE ci_foil.card_id = ci.card_id
+           AND ci_foil.quality = 'Near Mint'
+           AND ci_foil.foil_type = 'Foil'
+           LIMIT 1),
+          (SELECT price * 2.5 FROM card_inventory ci_base
+           WHERE ci_base.card_id = ci.card_id
+           AND ci_base.quality = 'Near Mint'
+           AND (ci_base.foil_type = 'Regular' OR ci_base.foil_type = 'Non-foil')
+           LIMIT 1)
+        ) as foil_price,
+        ci.price_source,
+        NOW()
+      FROM card_inventory ci
+      WHERE ci.stock_quantity = 0
+        AND ci.quality = 'Near Mint'
+        AND (ci.foil_type = 'Regular' OR ci.foil_type = 'Non-foil')
+      GROUP BY ci.card_id, ci.price_source
+      ON CONFLICT (card_id) DO NOTHING
+      RETURNING *;
+    `);
+
+    console.log(`   Migrated ${migrationResult.rowCount} pricing records`);
+
+    // Clean up: Remove all zero-quantity inventory entries
+    console.log('🧹 Removing zero-quantity inventory entries...');
+
+    const cleanupResult = await pool.query(`
+      DELETE FROM card_inventory WHERE stock_quantity = 0;
+    `);
+
+    console.log(`   Removed ${cleanupResult.rowCount} zero-quantity entries`);
+
+    console.log('\n' + '━'.repeat(60));
+    console.log('✅ MIGRATION COMPLETE');
+    console.log('━'.repeat(60));
+    console.log(`📋 Card pricing table created`);
+    console.log(`📦 ${migrationResult.rowCount} pricing records migrated`);
+    console.log(`🧹 ${cleanupResult.rowCount} zero-quantity entries removed`);
+    console.log('━'.repeat(60));
+
+  } catch (error) {
+    console.error('\n❌ Migration failed:', error);
+    console.error(error.stack);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+// Run the migration
+migrateCardPricing()
+  .then(() => {
+    console.log('\n✅ Migration completed successfully!\n');
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error('\n❌ Migration failed:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Fixes admin inventory table duplication issue reported in #51

## Problem
Card import scripts were creating zero-stock placeholder entries for every quality/foil combination, leading to database bloat and confusing admin UI with duplicate cards showing quantity=0.

## Solution
Complete architectural change to eliminate zero-quantity database entries:

- Import scripts now store base pricing in `card_pricing` table instead of creating inventory entries
- Admin backend dynamically generates quality/foil combinations from cards + existing inventory
- Virtual inventory entries with calculated prices, converted to real entries when updated
- Migration script to transition existing data and remove zero-stock entries

## Benefits
- Clean admin inventory view without quantity=0 duplicates
- Massive database efficiency improvement
- Maintains full admin functionality for adding any quality/foil combination
- Dynamic pricing based on quality discounts and foil multipliers

## Migration Required
Before deploying, run: `node scripts/migrate-card-pricing.js`

Closes #51

🤖 Generated with [Claude Code](https://claude.ai/code)