### PR TITLE
fix: resolve backend startup error - missing rateLimit function

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -38,6 +38,9 @@ const strictRateLimit = createRateLimit(60000, 30, 'Too many expensive operation
 const normalRateLimit = createRateLimit(60000, 100, 'Too many requests');             // 100 req/min
 const lenientRateLimit = createRateLimit(60000, 200, 'Too many requests');            // 200 req/min
 
+// Generic rateLimit function for dynamic rate limiting
+const rateLimit = (windowMs, max, message = 'Too many requests') => createRateLimit(windowMs, max, message);
+
 // ============================================
 // PUBLIC ROUTES
 // ============================================


### PR DESCRIPTION
**Issue Fixed:**
- Resolved ReferenceError: rateLimit is not defined that was preventing backend startup
- Added missing generic rateLimit function for dynamic rate limiting

**Technical Details:**
- The /api/search/autocomplete endpoint was calling rateLimit(60000, 50) but the function wasn't defined
- Created rateLimit function that wraps the existing createRateLimit helper
- Maintains consistency with existing rate limiting infrastructure

Resolves #63

🤖 Generated with [Claude Code](https://claude.ai/code)