### PR TITLE
Fix npm audit vulnerabilities

### DIFF
--- a/mana-meeples-shop/package.json
+++ b/mana-meeples-shop/package.json
@@ -12,7 +12,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.9.3",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "tailwindcss": "^3.4.1",
     "web-vitals": "^2.1.4"
   },
@@ -27,6 +27,11 @@
       "react-app",
       "react-app/jest"
     ]
+  },
+  "overrides": {
+    "nth-check": ">=2.0.1",
+    "postcss": ">=8.4.31",
+    "webpack-dev-server": ">=5.2.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Fix npm audit vulnerabilities

- Update react-scripts to use caret range (^5.0.1) for automatic patch updates
- Add package overrides to force safe versions of vulnerable dependencies:
  - nth-check: >=2.0.1 (fixes high severity vulnerability)
  - postcss: >=8.4.31 (fixes moderate severity vulnerability) 
  - webpack-dev-server: >=5.2.1 (fixes moderate security vulnerability)

These changes address all 9 npm audit issues by ensuring vulnerable transitive dependencies are updated to secure versions without requiring breaking changes.

Fixes #71

Generated with [Claude Code](https://claude.ai/code)