### PR TITLE
fix: replace restricted global 'confirm' with 'window.confirm' in AdminOrders

### DIFF
--- a/mana-meeples-shop/src/components/AdminOrders.jsx
+++ b/mana-meeples-shop/src/components/AdminOrders.jsx
@@ -395,7 +395,7 @@ const AdminOrders = () => {
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              if (confirm('Are you sure you want to cancel this order? This will restore inventory.')) {
+                              if (window.confirm('Are you sure you want to cancel this order? This will restore inventory.')) {
                                 updateOrderStatus(order.id, 'cancelled');
                               }
                             }}


### PR DESCRIPTION
Fixes ESLint no-restricted-globals error that was causing build failures on Render.

Changed line 398 in AdminOrders.jsx to use `window.confirm` instead of the global `confirm` function.

This fix addresses the build error reported in PR #70.

Generated with [Claude Code](https://claude.ai/code)