### PR TITLE
Fix undefined variable error in TCGShop.jsx

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -1891,8 +1891,8 @@ const TCGShop = () => {
 
       {/* ARIA Live Regions for Screen Reader Announcements */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {filteredGroupedCards.length > 0 && (
-          `Showing ${filteredGroupedCards.reduce((total, group) => total + group.cards.length, 0)} cards`
+        {groupedCards.length > 0 && (
+          `Showing ${groupedCards.reduce((total, group) => total + group.cards.length, 0)} cards`
         )}
       </div>
       <div aria-live="assertive" aria-atomic="true" className="sr-only">
@@ -1906,11 +1906,11 @@ const TCGShop = () => {
         aria-live="polite"
         aria-atomic="true"
         className="sr-only"
-        key={`search-${searchTerm}-${filteredGroupedCards.length}`}
+        key={`search-${searchTerm}-${groupedCards.length}`}
       >
         {searchTerm && !loading && (
-          filteredGroupedCards.length > 0
-            ? `Found ${filteredGroupedCards.reduce((total, group) => total + group.cards.length, 0)} cards matching "${searchTerm}"`
+          groupedCards.length > 0
+            ? `Found ${groupedCards.reduce((total, group) => total + group.cards.length, 0)} cards matching "${searchTerm}"`
             : `No cards found matching "${searchTerm}"`
         )}
       </div>


### PR DESCRIPTION
Fixes #84

This PR resolves the Render compilation issue caused by undefined variable references.

## Changes
- Fixed 5 instances where `filteredGroupedCards` was incorrectly used instead of `groupedCards`
- All changes are in ARIA live regions and search result announcements
- No functional changes, just correcting variable references

Generated with [Claude Code](https://claude.ai/code)