### PR TITLE
Fix undefined setCartVersion causing build failure

### DIFF
--- a/mana-meeples-shop/src/hooks/useEnhancedCart.js
+++ b/mana-meeples-shop/src/hooks/useEnhancedCart.js
@@ -109,7 +109,6 @@ export const useEnhancedCart = (API_URL) => {
 
       localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(cartWithMetadata));
       setLastSync(timestamp);
-      setCartVersion(newVersion);
       cartVersionRef.current = newVersion;
 
       // Broadcast cart update to other tabs
@@ -141,7 +140,6 @@ export const useEnhancedCart = (API_URL) => {
       if (version > cartVersionRef.current) {
         setCart(storedCart || []);
         setLastSync(timestamp);
-        setCartVersion(version);
         cartVersionRef.current = version;
       }
     } catch (error) {
@@ -157,7 +155,6 @@ export const useEnhancedCart = (API_URL) => {
       // Update from another tab
       setCart(broadcastCart || []);
       setLastSync(timestamp);
-      setCartVersion(version);
       cartVersionRef.current = version;
       addNotification('Cart synced from another tab', 'info', 2000);
     }


### PR DESCRIPTION
Fixes #89

Removed undefined setCartVersion calls from useEnhancedCart.js that were causing ESLint no-undef errors and preventing Render deployment.

Version tracking still works correctly via cartVersionRef.

Generated with [Claude Code](https://claude.ai/code)