### PR TITLE
Fix view toggle button movement in TCGShop

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -1323,13 +1323,15 @@ const TCGShop = () => {
           {/* Main Content */}
           <div className="flex-1">
             {/* Results Header */}
-            <div className="flex justify-between items-center mb-4 flex-wrap gap-3">
-              <p className="text-slate-600" aria-live="polite">
-                <span className="font-medium">{cards.length}</span> cards found
-              </p>
+            <div className="flex items-center mb-4 gap-3">
+              <div className="flex-1">
+                <p className="text-slate-600" aria-live="polite">
+                  <span className="font-medium">{cards.length}</span> cards found
+                </p>
+              </div>
 
-              {/* View Toggle */}
-              <div className="flex items-center gap-2">
+              {/* View Toggle - Fixed Position */}
+              <div className="flex items-center gap-2 flex-shrink-0">
                 <span className="text-sm text-slate-600 hidden sm:inline">View:</span>
                 <div className="inline-flex rounded-lg border border-slate-300 bg-white p-0.5">
                   <button


### PR DESCRIPTION
Fixes #88

## Summary
Fixed the view toggle button movement issue on the TCGShop desktop page. The button was shifting left/right when switching between grid and list views, but now maintains a stable position.

## Root Cause
The Results Header layout used `flex justify-between flex-wrap`, which caused the view toggle to shift position when:
- Card count text changed width ("10 cards" vs "1,000 cards")
- Flex container wrapped on different screen sizes
- Content reflow occurred during view changes

## Solution
Changed to a stable flex layout:
- Added `flex-1` to card count area to consume available space
- Added `flex-shrink-0` to view toggle container to prevent shrinking
- Removed `justify-between` and `flex-wrap` that caused layout shifts

## Testing
- ✅ View toggle button stays in fixed position
- ✅ No movement when switching between grid/list views
- ✅ Works consistently across desktop screen sizes
- ✅ Maintains responsive behavior without unwanted shifts

🤖 Generated with [Claude Code](https://claude.ai/code)