### PR TITLE
Fix view toggle button movement with absolute positioning

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -1323,24 +1323,25 @@ const TCGShop = () => {
           {/* Main Content */}
           <div className="flex-1">
             {/* Results Header */}
-            <div className="flex items-center mb-4 gap-3">
-              <div className="flex-1">
+            <div className="flex items-center mb-4">
+              <div className="flex-1 pr-4">
                 <p className="text-slate-600" aria-live="polite">
                   <span className="font-medium">{cards.length}</span> cards found
                 </p>
               </div>
 
-              {/* View Toggle - Fixed Position */}
-              <div className="flex items-center gap-2 flex-shrink-0">
-                <span className="text-sm text-slate-600 hidden sm:inline">View:</span>
-                <div className="inline-flex rounded-lg border border-slate-300 bg-white p-0.5">
+              {/* View Toggle - Absolutely Fixed Position */}
+              <div className="flex items-center gap-2 flex-shrink-0" style={{ minWidth: '140px', width: '140px' }}>
+                <span className="text-sm text-slate-600 hidden sm:inline" style={{ width: '36px' }}>View:</span>
+                <div className="inline-flex rounded-lg border border-slate-300 bg-white p-0.5" style={{ width: '96px' }}>
                   <button
                     onClick={() => setViewMode('grid')}
-                    className={`px-3 py-2 rounded-md transition-all ${
+                    className={`px-3 py-2 rounded-md transition-colors motion-reduce:transition-none ${
                       viewMode === 'grid'
                         ? 'bg-blue-600 text-white shadow-sm'
                         : 'text-slate-600 hover:text-slate-900 hover:bg-slate-50'
                     }`}
+                    style={{ width: '44px', minWidth: '44px' }}
                     aria-pressed={viewMode === 'grid'}
                     aria-label="Switch to grid view"
                   >
@@ -1348,11 +1349,12 @@ const TCGShop = () => {
                   </button>
                   <button
                     onClick={() => setViewMode('list')}
-                    className={`px-3 py-2 rounded-md transition-all ${
+                    className={`px-3 py-2 rounded-md transition-colors motion-reduce:transition-none ${
                       viewMode === 'list'
                         ? 'bg-blue-600 text-white shadow-sm'
                         : 'text-slate-600 hover:text-slate-900 hover:bg-slate-50'
                     }`}
+                    style={{ width: '44px', minWidth: '44px' }}
                     aria-pressed={viewMode === 'list'}
                     aria-label="Switch to list view"
                   >


### PR DESCRIPTION
Fixes #88

## Summary
Completely eliminates view toggle button movement when switching between grid and list views on the TCGShop desktop page.

## Root Cause
The button was still experiencing micro-movements due to:
- Flex gap causing positioning shifts
- `transition-all` affecting layout properties
- Dynamic content width variations
- Lack of explicit width constraints

## Solution
Applied comprehensive positioning fix:
- **Fixed Container Width**: 140px total width constraint
- **Component Widths**: "View:" label (36px), button container (96px)
- **Button Constraints**: 44px width each to prevent size variations
- **Optimized Transitions**: Changed from `transition-all` to `transition-colors`
- **Layout Stability**: Removed flex gap, added padding for spacing

## Testing
- ✅ Button stays completely stationary during view switches
- ✅ No movement with varying card counts
- ✅ Maintains responsive behavior and accessibility
- ✅ Works consistently across desktop screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)