### PR TITLE
fix: eliminate view toggle button movement by standardizing SectionHeader positioning

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -1472,8 +1472,8 @@ const TCGShop = () => {
               <div>
                 {groupedCards.map((group, groupIndex) => (
                   <div key={groupIndex} className="mb-8">
+                    <SectionHeader title={group.section} count={group.cards.length} isGrid={false} />
                     <div className="space-y-2">
-                      <SectionHeader title={group.section} count={group.cards.length} isGrid={false} />
                       {group.cards.map(card => {
                         const selectedVariationKey = selectedVariations[card.id] || card.variations[0]?.variation_key;
                         const selectedVariation = card.variations.find(v => v.variation_key === selectedVariationKey) || card.variations[0];


### PR DESCRIPTION
Complete fix for issue #88 - eliminates view toggle button movement by standardizing SectionHeader positioning between Grid and List views.

Moves SectionHeader outside space-y-2 container in List View to match Grid View structure, ensuring identical spacing and preventing layout shift.

🤖 Generated with [Claude Code](https://claude.ai/code)