### PR TITLE
fix: Add missing filterCounts destructuring in TCGShop component

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -355,7 +355,7 @@ const TCGShop = () => {
   }), [searchParams]);
 
   // Filter counts hook for dynamic counts in dropdowns
-  const { getCount } = useFilterCounts(API_URL, { ...filters, game: selectedGame });
+  const { getCount, filterCounts } = useFilterCounts(API_URL, { ...filters, game: selectedGame });
 
   const [showMobileFilters, setShowMobileFilters] = useState(false);
   const [filterOptions, setFilterOptions] = useState({


### PR DESCRIPTION
Fixes build error where filterCounts was undefined on line 1176 in TCGShop.jsx.

The useFilterCounts hook returns filterCounts but it wasn't being destructured from the hook return value. This caused a build failure in Render with ESLint error: 'filterCounts' is not defined no-undef.

Generated with [Claude Code](https://claude.ai/code)