### PR TITLE
fix: Resolve 429 rate limiting errors and React hooks warning

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -484,8 +484,14 @@ const TCGShop = () => {
         // Load games first (most important)
         const gamesRes = await withRetry(() => throttledFetch(`${API_URL}/games`));
 
+        // Add a delay before the next API call to ensure rate limiting
+        await new Promise(resolve => setTimeout(resolve, 600));
+
         // Load filters next
         const filtersRes = await withRetry(() => throttledFetch(`${API_URL}/filters`));
+
+        // Add another delay before optional currency detection
+        await new Promise(resolve => setTimeout(resolve, 600));
 
         // Currency detection can happen in background (optional)
         withRetry(() => throttledFetch(`${API_URL}/currency/detect`)).catch(err => {
@@ -798,7 +804,7 @@ const TCGShop = () => {
       setLoading(false);
       requestInFlight.current.cards = false;
     }
-  }, [searchTerm, selectedGame, filters, games, currency.rate]);
+  }, [searchTerm, selectedGame, filters, games, currency.rate, handleError]);
 
   useEffect(() => {
     if (games.length > 0) {

--- a/mana-meeples-shop/src/services/errorHandler.js
+++ b/mana-meeples-shop/src/services/errorHandler.js
@@ -208,7 +208,7 @@ export const withRetry = async (operation, maxRetries = 3, delay = 1000) => {
           attempts: attempt,
           operation: operation.name || 'anonymous',
           rateLimited: true,
-          message: 'Rate limit exceeded. Please wait before making more requests.'
+          message: 'Rate limit exceeded. The server is currently busy. Please wait a moment and refresh the page.'
         });
       }
 

--- a/mana-meeples-shop/src/services/requestThrottler.js
+++ b/mana-meeples-shop/src/services/requestThrottler.js
@@ -9,8 +9,8 @@ class RequestThrottler {
     this.activeRequests = new Map();
     // Track request timestamps to implement rate limiting
     this.requestHistory = new Map();
-    // Minimum delay between requests to same endpoint (in ms)
-    this.minDelay = 500;
+    // Minimum delay between requests to same endpoint (in ms) - increased to prevent 429s
+    this.minDelay = 800;
     // Maximum concurrent requests per endpoint
     this.maxConcurrent = 1;
   }


### PR DESCRIPTION
This PR addresses the remaining 429 rate limiting issues and React hooks warning reported after PR #117.

## Key Fixes:

- **React Hooks Fix**: Added missing `handleError` dependency to `fetchCards` useCallback
- **Enhanced Rate Limiting**: Increased RequestThrottler delay from 500ms to 800ms
- **Sequential Delays**: Added 600ms delays between API calls in fetchInitialData
- **Better Error Messages**: Improved 429 error messaging for users

## Technical Details:

The remaining 429 errors were caused by API calls in `fetchInitialData` being too close together, even with throttling. The solution adds explicit delays and increases the base throttling delay.

Generated with [Claude Code](https://claude.ai/code)