### PR TITLE
fix: Resolve infinite API call loop causing UI flickering

### DIFF
--- a/mana-meeples-shop/src/components/TCGShop.jsx
+++ b/mana-meeples-shop/src/components/TCGShop.jsx
@@ -29,9 +29,12 @@ const TCGShop = () => {
 
   // Create a stable handleError function to prevent unnecessary re-renders
   const errorHandler = useErrorHandler();
+  const errorHandlerRef = useRef(errorHandler);
+  errorHandlerRef.current = errorHandler; // Always keep ref up to date
+
   const handleError = useCallback((error, context) => {
-    return errorHandler.handleError(error, context);
-  }, [errorHandler]);
+    return errorHandlerRef.current.handleError(error, context);
+  }, []); // No dependencies - use ref for current value
   const [showCart, setShowCart] = useState(false);
   const [showMiniCart, setShowMiniCart] = useState(false);
   const [showCheckout, setShowCheckout] = useState(false);

--- a/mana-meeples-shop/src/hooks/useFilterCounts.js
+++ b/mana-meeples-shop/src/hooks/useFilterCounts.js
@@ -167,7 +167,7 @@ export const useFilterCounts = (API_URL, currentFilters = {}) => {
         abortControllerRef.current.abort();
       }
     };
-  }, [currentFilters, fetchFilterCounts, isCacheValid, API_URL]);
+  }, [currentFilters, fetchFilterCounts, API_URL]);
 
   // Format count for display
   const formatCount = (count) => {


### PR DESCRIPTION
This PR fixes the infinite API call loop that was causing UI flickering reported in PR #119.

## Changes:
- Fixed React Hook dependency cycles in useFilterCounts hook
- Stabilized handleError callback to prevent unnecessary re-renders
- Eliminates continuous loop of /filters/counts and /cards API calls

## Result:
- No more UI flickering
- Stable performance with proper API throttling
- All existing functionality preserved

Generated with [Claude Code](https://claude.ai/code)