### PR TITLE
fix: add padding to card-mm class for proper content spacing

### DIFF
--- a/mana-meeples-shop/src/index.css
+++ b/mana-meeples-shop/src/index.css
@@ -50,7 +50,7 @@
 
   /* M&M Card Styles */
   .card-mm {
-    @apply bg-white border-2 border-mm-warmAccent rounded-mm-md transition-all duration-300 shadow-mm-card;
+    @apply bg-white border-2 border-mm-warmAccent rounded-mm-md p-6 transition-all duration-300 shadow-mm-card;
   }
 
   .card-mm:hover,


### PR DESCRIPTION
Fixes the missing padding issue in the search & filters box and other card-style components.

The card-mm CSS class was missing internal padding, causing content to touch the edges of cards. Added p-6 (1.5rem padding) to ensure proper content spacing.

References the original brand transformation PR #128.

🤖 Generated with [Claude Code](https://claude.ai/code)