### PR TITLE
fix: replace restricted global confirm with window.confirm

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -1139,7 +1139,7 @@ const AdminDashboard = () => {
 
                     <button
                       onClick={() => {
-                        if (confirm(`Delete ${selectedItems.size} selected items? This cannot be undone.`)) {
+                        if (window.confirm(`Delete ${selectedItems.size} selected items? This cannot be undone.`)) {
                           executeBulkOperation('delete');
                         }
                       }}


### PR DESCRIPTION
Fixes ESLint error 'Unexpected use of 'confirm' no-restricted-globals' that was preventing the production build from completing.

This change replaces the restricted global `confirm()` with `window.confirm()` in AdminDashboard.jsx line 1142, maintaining identical functionality while satisfying ESLint rules.

Generated with [Claude Code](https://claude.ai/code)