### PR TITLE
fix: resolve ESLint build warnings in AdminDashboard and AllCardsView

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -269,6 +269,44 @@ const AdminDashboard = () => {
     }
   }, [filters]);
 
+  // Export filtered results
+  const exportFilteredResults = useCallback(() => {
+    const currentResults = [];
+
+    filteredInventory.forEach(group => {
+      group.qualities.forEach(item => {
+        currentResults.push([
+          item.sku,
+          `"${group.card_name}"`,
+          group.game,
+          group.set,
+          item.set_code || '',
+          item.number || '',
+          item.quality,
+          item.foil_type || 'Regular',
+          item.language || 'English',
+          item.price,
+          item.stock,
+          item.price_source || '',
+          item.last_updated || ''
+        ].join(','));
+      });
+    });
+
+    const csv = [
+      ['SKU', 'Name', 'Game', 'Set', 'Set Code', 'Number', 'Quality', 'Foil Type', 'Language', 'Price', 'Stock', 'Price Source', 'Last Updated'].join(','),
+      ...currentResults
+    ].join('\n');
+
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `filtered-inventory-${new Date().toISOString().split('T')[0]}.csv`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }, [filteredInventory]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyPress = (e) => {
@@ -919,44 +957,6 @@ const AdminDashboard = () => {
     } finally {
       setTimeout(() => setQuickActionState('idle'), 3000);
     }
-  };
-
-  // Export filtered results
-  const exportFilteredResults = () => {
-    const currentResults = [];
-
-    filteredInventory.forEach(group => {
-      group.qualities.forEach(item => {
-        currentResults.push([
-          item.sku,
-          `"${group.card_name}"`,
-          group.game,
-          group.set,
-          item.set_code || '',
-          item.number || '',
-          item.quality,
-          item.foil_type || 'Regular',
-          item.language || 'English',
-          item.price,
-          item.stock,
-          item.price_source || '',
-          item.last_updated || ''
-        ].join(','));
-      });
-    });
-
-    const csv = [
-      ['SKU', 'Name', 'Game', 'Set', 'Set Code', 'Number', 'Quality', 'Foil Type', 'Language', 'Price', 'Stock', 'Price Source', 'Last Updated'].join(','),
-      ...currentResults
-    ].join('\n');
-
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `filtered-inventory-${new Date().toISOString().split('T')[0]}.csv`;
-    a.click();
-    window.URL.revokeObjectURL(url);
   };
 
   // Quick analytics calculation

--- a/mana-meeples-shop/src/components/AllCardsView.jsx
+++ b/mana-meeples-shop/src/components/AllCardsView.jsx
@@ -18,10 +18,6 @@ const AllCardsView = () => {
   const [expandedCards, setExpandedCards] = useState(new Set());
 
   // Fetch cards from API
-  useEffect(() => {
-    fetchCards();
-  }, [fetchCards]);
-
   const fetchCards = useCallback(async () => {
     setLoading(true);
     try {
@@ -51,6 +47,10 @@ const AllCardsView = () => {
       setLoading(false);
     }
   }, [filterGame, filterSet, filterTreatment, filterFinish]);
+
+  useEffect(() => {
+    fetchCards();
+  }, [fetchCards]);
 
   // Filter cards by search term
   const filteredCards = useMemo(() => {


### PR DESCRIPTION
This PR fixes the ESLint warnings that were appearing during the build process.

## Changes

- **AdminDashboard.jsx**: Moved `exportFilteredResults` function before useEffect and wrapped in useCallback
- **AllCardsView.jsx**: Moved `fetchCards` function before useEffect
- Removed duplicate function definitions

## Issues Fixed

- `no-use-before-define`: Functions used in useEffect dependencies before definition
- `react-hooks/exhaustive-deps`: useEffect dependency changing on every render

The build should now complete without ESLint warnings.

Generated with [Claude Code](https://claude.com/claude-code)