### PR TITLE
fix: resolve ESLint no-use-before-define warning and server error

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -21,7 +21,7 @@ const { sanitizeCustomerData } = require('../utils/sanitization');
 const expressRateLimit = require('express-rate-limit');
 
 const variationRoutes = require('./variations');
-app.use('/api', variationRoutes);
+router.use('/', variationRoutes);
 
 // Create memory-safe rate limiters using express-rate-limit
 const createRateLimit = (windowMs, max, message = 'Too many requests') => expressRateLimit({


### PR DESCRIPTION
This PR fixes the remaining ESLint warnings and server errors reported after PR #142.

## Changes

- **AdminDashboard.jsx**: Moved `filteredInventory` and `groupedInventory` definitions before `exportFilteredResults` function
- **api.js**: Fixed undefined `app` reference by changing to `router.use`

## Issues Fixed

- `no-use-before-define`: Functions used in useEffect dependencies before definition
- `ReferenceError`: app is not defined in router file

The build should now complete without ESLint warnings and the server should start without errors.

Generated with [Claude Code](https://claude.ai/code)