### PR TITLE
fix: correct adminAuthJWT reference to use adminAuth alias

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -1501,7 +1501,7 @@ router.get('/analytics/trending', async (req, res) => {
  * Groups by base card (same name + card_number) and shows finish variations
  * Does NOT generate inventory - just shows what's in the database
  */
-router.get('/admin/all-cards', adminAuthJWT, async (req, res) => {
+router.get('/admin/all-cards', adminAuth, async (req, res) => {
   try {
     const {
       game_id,


### PR DESCRIPTION
This PR fixes a production deployment error where the server was failing to start due to `ReferenceError: adminAuthJWT is not defined`.

## Problem
The middleware was imported with an alias:
```javascript
const { adminAuthJWT: adminAuth, ... } = require('../middleware/auth');
```

But referenced by the original name in the route definition:
```javascript
router.get('/admin/all-cards', adminAuthJWT, async (req, res) => {
```

## Solution
- Changed `adminAuthJWT` to `adminAuth` on line 1504 to match the imported alias

Generated with [Claude Code](https://claude.ai/code)