### PR TITLE
fix: resolve JSX syntax error in AdminDashboard

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -1695,7 +1695,6 @@ const AdminDashboard = () => {
           </div>
         </div>
       </div>
-    )}
 
         {/* Analytics Dashboard */}
         {Object.keys(analyticsData.gameBreakdown).length > 0 && (
@@ -1770,6 +1769,8 @@ const AdminDashboard = () => {
             </div>
           </div>
         )}
+      </div>
+    )}
 
         {/* Bulk Operation Modals */}
         {bulkOperation && (


### PR DESCRIPTION
Fixes the JSX syntax error that was causing build failures in AdminDashboard.jsx.

## Changes
- Fixed incorrect closing JSX structure in inventory tab section
- Moved Analytics Dashboard inside inventory conditional block
- Ensures proper nesting of JSX elements

Resolves build error: "Expected corresponding JSX closing tag for <main>"

Related to PR #151

🤖 Generated with [Claude Code](https://claude.ai/code)