### PR TITLE
fix: resolve JSX syntax error in AdminDashboard

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -1694,7 +1694,6 @@ const AdminDashboard = () => {
             </div>
           </div>
         </div>
-      </div>
 
         {/* Analytics Dashboard */}
         {Object.keys(analyticsData.gameBreakdown).length > 0 && (


### PR DESCRIPTION
Fixes the JSX syntax error that was causing build failures in AdminDashboard.jsx.

## Changes
- Removed erroneous closing </div> tag at line 1697
- Analytics Dashboard now properly remains inside inventory tab conditional
- Ensures proper nesting of JSX elements

Resolves build error: "Expected corresponding JSX closing tag for <main>"

Related to PR #152

🤖 Generated with [Claude Code](https://claude.ai/code)