### PR TITLE
fix: correct JSX structure in AdminDashboard inventory section

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -1767,9 +1767,8 @@ const AdminDashboard = () => {
               </div>
             </div>
           </div>
+        </div>
         )}
-      </div>
-    )}
 
         {/* Bulk Operation Modals */}
         {bulkOperation && (


### PR DESCRIPTION
Fixes the JSX syntax error that was causing build failures in AdminDashboard.jsx.

## Changes
- Fixed missing closing div tag for inventory container (line 1770)
- Properly close inventory conditional block (line 1771)
- Ensures proper nesting of JSX elements

Resolves build error: "Expected corresponding JSX closing tag for <main>"

Related to PR #152

🤖 Generated with [Claude Code](https://claude.ai/code)