### PR TITLE
fix: remove orphaned JSX fragment closing tag

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -3049,7 +3049,6 @@ const AdminDashboard = () => {
             </div>
           </div>
         )}
-          </>
         )}
 
         {/* Orders Tab */}


### PR DESCRIPTION
Fixes the JSX syntax error that was causing build failures in AdminDashboard.jsx.

## Changes
- Removed orphaned JSX fragment closing tag `</>` at line 3052
- No other changes needed - this was a single orphaned tag issue

Resolves build error: "Expected corresponding JSX closing tag for <main>"

Related to PR #152

🤖 Generated with [Claude Code](https://claude.ai/code)