### PR TITLE
fix: Remove undefined setQuickActionState references

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -942,7 +942,6 @@ const AdminDashboard = () => {
   const executeBulkOperation = async (operation, data = {}) => {
     if (selectedItems.size === 0) return;
 
-    setQuickActionState('loading');
     try {
       const selectedItemsArray = Array.from(selectedItems);
 
@@ -962,7 +961,6 @@ const AdminDashboard = () => {
       }
 
       const result = await response.json();
-      setQuickActionState('success');
 
       // Refresh inventory after bulk operation
       window.location.reload();
@@ -973,11 +971,8 @@ const AdminDashboard = () => {
 
       window.alert(`Bulk operation completed! Updated ${result.updated} items.`);
     } catch (error) {
-      setQuickActionState('error');
       console.error('Bulk operation error:', error);
       window.alert(`Bulk operation failed: ${error.message}`);
-    } finally {
-      setTimeout(() => setQuickActionState('idle'), 3000);
     }
   };
 


### PR DESCRIPTION
Resolves ESLint no-undef compilation errors in AdminDashboard.jsx

- Remove setQuickActionState calls from executeBulkOperation function
- Fixes ESLint no-undef errors on lines 945, 965, 976, and 980
- Maintains all existing functionality while cleaning up orphaned state calls

Closes #157

Generated with [Claude Code](https://claude.ai/code)