### PR TITLE
fix: Move fetchInventoryList definition before usage

### DIFF
--- a/mana-meeples-shop/src/components/AdminDashboard.jsx
+++ b/mana-meeples-shop/src/components/AdminDashboard.jsx
@@ -484,6 +484,38 @@ const AdminDashboard = () => {
     return () => window.removeEventListener('keydown', handleKeyPress);
   }, [searchTerm, toast, exportFilteredResults]);
 
+  // NEW: Fetch inventory in list format
+  const fetchInventoryList = useCallback(async () => {
+    setInventoryLoading(true);
+    try {
+      const params = new URLSearchParams({
+        game: filterGame || 'all',
+        set: filterSet || 'all',
+        search: searchTerm,
+        treatment: 'all',
+        finish: 'all',
+        sort: inventorySortOrder
+      });
+
+      const response = await fetch(`${API_URL}/admin/inventory-list?${params}`, {
+        credentials: 'include',
+        headers: getAdminHeaders()
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch inventory');
+      }
+
+      const data = await response.json();
+      setInventoryCards(data.cards);
+    } catch (error) {
+      console.error('Error fetching inventory list:', error);
+      window.alert('Failed to load inventory');
+    } finally {
+      setInventoryLoading(false);
+    }
+  }, [filterGame, filterSet, searchTerm, inventorySortOrder]);
+
   // NEW: Fetch inventory list when filters change
   useEffect(() => {
     if (activeTab === 'inventory') {
@@ -711,38 +743,6 @@ const AdminDashboard = () => {
       setLoading(false);
     }
   };
-
-  // NEW: Fetch inventory in list format
-  const fetchInventoryList = useCallback(async () => {
-    setInventoryLoading(true);
-    try {
-      const params = new URLSearchParams({
-        game: filterGame || 'all',
-        set: filterSet || 'all',
-        search: searchTerm,
-        treatment: 'all',
-        finish: 'all',
-        sort: inventorySortOrder
-      });
-
-      const response = await fetch(`${API_URL}/admin/inventory-list?${params}`, {
-        credentials: 'include',
-        headers: getAdminHeaders()
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch inventory');
-      }
-
-      const data = await response.json();
-      setInventoryCards(data.cards);
-    } catch (error) {
-      console.error('Error fetching inventory list:', error);
-      window.alert('Failed to load inventory');
-    } finally {
-      setInventoryLoading(false);
-    }
-  }, [filterGame, filterSet, searchTerm, inventorySortOrder]);
 
   // NEW: Toggle card expansion in inventory view
   const toggleInventoryCard = (cardKey) => {


### PR DESCRIPTION
Resolves ESLint no-use-before-define warning by moving fetchInventoryList function definition before its usage in useEffect dependency array.

- Move fetchInventoryList from line 748 to line 487
- Function is now defined before first usage on line 530
- Eliminates build warning while maintaining all functionality

Closes #157

Generated with [Claude Code](https://claude.ai/code)