### PR TITLE
fix: change static service type to web in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,7 +16,7 @@ services:
         value: 10000
 
   # Frontend Web Service
-  - type: static
+  - type: web
     name: mana-meeples-web
     env: static
     buildCommand: corepack enable && pnpm install && pnpm --filter ./apps/web run build


### PR DESCRIPTION
**Summary**
- Fix invalid `type: static` in render.yaml 
- Change to `type: web` with `env: static` for static sites
- Render blueprints don't support `type: static` service type

**Test plan**
- [ ] Deploy to Render using corrected render.yaml
- [ ] Verify both API and web services build successfully
- [ ] Test that static site deploys correctly with SPA routing

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/code)