### PR TITLE
fix: resolve Render deployment TypeScript build errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
@@ -18,6 +19,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/compression": "^1.7.9",
     "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.19",
     "@types/dotenv": "^8.2.3",


### PR DESCRIPTION
**Summary**
- Add missing @types/compression dependency to resolve compilation error
- Set package.json type to 'module' to fix import.meta usage
- This resolves TypeScript build errors in Render deployment

**Test plan**
- [ ] Deploy to Render using updated configuration
- [ ] Verify TypeScript compilation succeeds without errors
- [ ] Test API service starts correctly with ESM imports
- [ ] Verify compression middleware works properly

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/code)