### PR TITLE
fix: replace wildcard route pattern * with /* for path-to-regexp v8 compatibility

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -77,7 +77,7 @@ app.use(
 );
 
 // SPA fallback (must come AFTER API and static)
-app.get('*', (_req: Request, res: Response, next: NextFunction) => {
+app.get('/*', (_req: Request, res: Response, next: NextFunction) => {
   // If request accepts HTML, serve index.html to let the client router handle it
   const accept = _req.headers.accept || '';
   if (accept.includes('text/html')) {


### PR DESCRIPTION
**Summary**
- Fix Render deployment runtime error caused by invalid wildcard route pattern
- Change `app.get('*', ...)` to `app.get('/*', ...)` in server.ts
- Required for compatibility with path-to-regexp v8.x used by Express 5.x

**Test plan**
- [ ] Deploy to Render and verify server starts without runtime errors
- [ ] Test SPA routing works correctly
- [ ] Verify API endpoints are accessible
- [ ] Test static asset serving

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/code)