### PR TITLE
fix: replace wildcard route pattern * with /* for path-to-regexp v8 compatibility

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -52,7 +52,7 @@ export function createApp() {
   const frontendDist = path.join(__dirname, "../web/dist");
 
   app.use(express.static(frontendDist));
-  app.get("*", (_req, res) => {
+  app.get("/*", (_req, res) => {
     res.sendFile(path.join(frontendDist, "index.html"));
   });
 


### PR DESCRIPTION
**Summary**
- Fix Render deployment runtime error caused by invalid wildcard route pattern
- Change `app.get('*', ...)` to `app.get('/*', ...)` in app.ts
- Required for compatibility with path-to-regexp v8.x used by Express 5.x

**Test plan**
- [ ] Deploy to Render and verify server starts without runtime errors
- [ ] Test SPA routing works correctly
- [ ] Verify API endpoints are accessible
- [ ] Test static asset serving

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/code)