### PR TITLE
fix: update /api/health/db response format

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -59,13 +59,11 @@ app.get('/api/health', (_req: Request, res: Response) => {
 app.get('/api/health/db', async (_req, res) => {
   try {
     const ok = await healthcheck();
-    if (!ok) return res.status(500).json({ db: false, error: 'probe returned false' });
-    res.status(200).json({ db: true });
+    if (!ok) return res.status(500).json({ database: 'disconnected' });
+    res.status(200).json({ database: 'connected' });
   } catch (err: any) {
     res.status(500).json({
-      db: false,
-      error: err?.message ?? 'unknown',
-      code: err?.code,
+      database: 'disconnected',
     });
   }
 });


### PR DESCRIPTION
Change response from {db: true/false} to {database: 'connected'/'disconnected'} to match expected format in smoke test.

Fixes issue where smoke test warned about missing 'database' key.

Closes #180

Generated with [Claude Code](https://claude.ai/code)