### PR TITLE
fix: update Render build command to include web files

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
   - type: web
     name: mana-meeples-api
     env: node
-    buildCommand: corepack enable && pnpm install --no-frozen-lockfile && pnpm --filter ./apps/api run build
+    buildCommand: corepack enable && pnpm install --no-frozen-lockfile && pnpm run build:render
     startCommand: cd apps/api && node dist/server.js
     envVars:
       - key: NODE_VERSION


### PR DESCRIPTION
Change API service build command from building only the API to using the build:render script which:

1. Builds the web app (apps/web/dist)
2. Builds the API (apps/api/dist)
3. Copies web files to apps/api/dist/public

This fixes the website accessibility issue where static files weren't being served from the API service.

Closes #180

🤖 Generated with [Claude Code](https://claude.ai/code)