### PR TITLE
fix: use relative paths for /shop/ base URL

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="TCG Singles Shop - Mana & Meeples" />
-    <link rel="apple-touch-icon" href="/logo192.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="./logo192.png" />
+    <link rel="manifest" href="./manifest.json" />
     <title>Mana & Meeples - TCG Singles</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!-- IMPORTANT: point to your actual entry file -->
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
     <!-- If your entry is main.tsx, change to: /src/main.tsx -->
   </body>
 </html>

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -3,17 +3,17 @@
   "name": "Create React App Sample",
   "icons": [
     {
-      "src": "favicon.ico",
+      "src": "./favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "./logo192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "./logo512.png",
       "type": "image/png",
       "sizes": "512x512"
     }


### PR DESCRIPTION
Change absolute paths to relative paths in index.html and manifest.json to work correctly with Vite's base: '/shop/' configuration.

This fixes 404 errors for assets like JS files, manifest.json, and favicon.ico when accessing the site through the API service.

Closes #180

🤖 Generated with [Claude Code](https://claude.ai/code)