### PR TITLE
fix: update manifest.json with proper Mana Meeples branding

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -1,9 +1,9 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Mana Meeples",
+  "name": "Mana Meeples Singles Market",
   "icons": [
     {
-      "src": "./favicon.ico",
+      "src": "./mana_meeples_logo.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },


### PR DESCRIPTION
Fixes #185

Updated the web app manifest file to use proper Mana Meeples Singles Market branding instead of generic Create React App template values.

**Changes:**
- Replace generic 'Create React App Sample' name with 'Mana Meeples Singles Market'
- Update short_name from 'React App' to 'Mana Meeples'
- Reference custom mana_meeples_logo.ico instead of generic favicon.ico

This ensures PWA installation prompts and home screen shortcuts display with the correct branding.

Generated with [Claude Code](https://claude.ai/code)