### PR TITLE
fix: correct case-sensitive import path for App component

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./app";
+import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
Fixes import from './app' to './App' in main.tsx to resolve build failures on case-sensitive filesystems like Linux/Render.

Resolves #187

Generated with [Claude Code](https://claude.ai/code)