### PR TITLE
fix: change Vite base path from /shop/ to / to match deployment structure

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/shop/',   // <-- important
+  base: '/',   // Changed from '/shop/' to match deployment at root path
 })


### PR DESCRIPTION
The site is deployed at the root path but Vite was configured with base: '/shop/'
causing 404 errors for JavaScript assets. Changed to base: '/' to fix asset loading.

Resolves #187

Generated with [Claude Code](https://claude.ai/code)