### PR TITLE
fix: remove /shop basename from React Router and update Render routes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,7 +22,7 @@ export default function App() {
   return (
     <ErrorBoundary>
       <ToastProvider>
-        <BrowserRouter basename="/shop">
+        <BrowserRouter>
           <Suspense fallback={<LoadingSpinner />}>
             <Routes>
               <Route path="/" element={<TCGShop />} />

--- a/render.yaml
+++ b/render.yaml
@@ -23,5 +23,5 @@ services:
     staticPublishPath: ./apps/web/dist
     routes:
       - type: rewrite
-        source: /shop/*
-        destination: /shop/index.html
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
Fixes routing mismatch that prevented React app from loading properly:

- Remove basename='/shop' from BrowserRouter to match root deployment
- Update render.yaml routes from /shop/* to /* for proper SPA routing

Resolves #187

Generated with [Claude Code](https://claude.ai/code)