### PR TITLE
fix: replace hardcoded API paths with configured API helper functions

### DIFF
--- a/apps/web/src/components/DynamicVariationFilter.tsx
+++ b/apps/web/src/components/DynamicVariationFilter.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { api } from '../config/api';
 
 /**
  * Dynamic Variation Filter Component
@@ -38,13 +39,13 @@ const DynamicVariationFilter = ({
           params.append('game_id', selectedGame);
         }
         
-        const response = await fetch(`${apiUrl}/variations/filters?${params}`);
-        
-        if (!response.ok) {
-          throw new Error('Failed to fetch filters');
-        }
-        
-        const data = await response.json();
+        const data = await api.get<{
+          treatments?: any[];
+          borderColors?: any[];
+          finishes?: any[];
+          promoTypes?: any[];
+          frameEffects?: any[];
+        }>(`/variations/filters?${params}`);
         
         setAvailableFilters({
           treatments: data.treatments || [],

--- a/apps/web/src/components/FiltersPanel.tsx
+++ b/apps/web/src/components/FiltersPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { api } from '../config/api';
 
 
 type FilterRow = { treatment?: string; border_color?: string; finish?: string; promo_type?: string; frame_effect?: string };
@@ -10,7 +11,17 @@ const [data, setData] = useState<FilterRow[]>([]);
 const announceRef = useRef<HTMLDivElement>(null);
 
 
-useEffect(() => { (async () => { const r = await fetch('/api/filters'); setData((await r.json()).data ?? []); })(); }, []);
+useEffect(() => {
+  (async () => {
+    try {
+      const response = await api.get<{ data: FilterRow[] }>('/filters');
+      setData(response.data ?? []);
+    } catch (error) {
+      console.error('Failed to fetch filters:', error);
+      setData([]);
+    }
+  })();
+}, []);
 useEffect(() => { if (announceRef.current) announceRef.current.textContent = `Loaded ${data.length} filter values`; }, [data]);
 
 

--- a/apps/web/src/features/cards/api.ts
+++ b/apps/web/src/features/cards/api.ts
@@ -1,14 +1,14 @@
 
 import { useQuery } from '@tanstack/react-query';
+import { api } from '../config/api';
 
 
 export function useCardSearch(q: string) {
 return useQuery({
 queryKey: ['cards', q],
 queryFn: async () => {
-const r = await fetch(`/api/cards?q=${encodeURIComponent(q)}`);
-if (!r.ok) throw new Error('search failed');
-return (await r.json()).data as Array<{ id: number; name: string; sku: string; finish: string; card_number: string }>;
+const response = await api.get<{ data: Array<{ id: number; name: string; sku: string; finish: string; card_number: string }> }>(`/cards?q=${encodeURIComponent(q)}`);
+return response.data;
 },
 enabled: q.length > 1,
 });


### PR DESCRIPTION
Fixes JSON parsing errors by ensuring all API calls use the correct backend URL:

- Replace hardcoded fetch('/api/...') calls with api.get() helper
- Add proper TypeScript types for API responses
- Add error handling where missing
- Ensures frontend calls backend service instead of frontend service

Resolves #187

Generated with [Claude Code](https://claude.ai/code)