### PR TITLE
fix: add missing CSS import to enable Tailwind styles

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import "./styles/index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
The app was loading but without any styling because the CSS file
containing Tailwind directives and custom M&M brand styles was
never imported into the application.

Added import for `./styles/index.css` in main.tsx to fix styling.

Resolves #187

🤖 Generated with [Claude Code](https://claude.ai/code)