### PR TITLE
Fix games dropdown: show all active games regardless of inventory

### DIFF
--- a/apps/api/src/routes/api.ts
+++ b/apps/api/src/routes/api.ts
@@ -263,12 +263,17 @@ router.get("/games", async (req: Request, res: Response) => {
       g.name,
       g.code,
       g.active,
-      COUNT(DISTINCT c.id) AS card_count
+      COALESCE(card_counts.card_count, 0) AS card_count
     FROM games g
-    LEFT JOIN cards c ON c.game_id = g.id
-    LEFT JOIN card_inventory i ON i.card_id = c.id AND i.stock_quantity > 0
+    LEFT JOIN (
+      SELECT
+        c.game_id,
+        COUNT(DISTINCT c.id) AS card_count
+      FROM cards c
+      JOIN card_inventory i ON i.card_id = c.id AND i.stock_quantity > 0
+      GROUP BY c.game_id
+    ) card_counts ON card_counts.game_id = g.id
     WHERE g.active = true
-    GROUP BY g.id, g.name, g.code, g.active
     ORDER BY g.name ASC
   `;
 


### PR DESCRIPTION
Resolves #196

This PR implements Option A from the search functionality analysis to fix the games dropdown population issue.

## Changes Made
- Updated `/games` endpoint query to use subquery approach
- Games now appear in dropdown even without inventory stock
- Card counts accurately reflect only cards with stock > 0
- Resolves dropdown population issue in TCGshop and admindashboard

## Expected Results
The games dropdown should now populate with all active games, showing accurate card counts for items in stock.

Generated with [Claude Code](https://claude.ai/code)