### PR TITLE
fix: Convert admin debug scripts from CommonJS to ES modules

### DIFF
--- a/scripts/debug-admin-login.ts
+++ b/scripts/debug-admin-login.ts
@@ -1,6 +1,8 @@
-require('dotenv').config();
-const bcrypt = require('bcrypt');
-const readline = require('readline');
+import { config } from 'dotenv';
+import bcrypt from 'bcrypt';
+import readline from 'readline';
+
+config();
 
 async function debugAdminLogin() {
   const username = process.env.ADMIN_USERNAME;

--- a/scripts/generate-admin-hash.ts
+++ b/scripts/generate-admin-hash.ts
@@ -1,6 +1,5 @@
-// @ts-expect-error TS(2451): Cannot redeclare block-scoped variable 'bcrypt'.
-const bcrypt = require('bcrypt');
-const readline = require('readline');
+import bcrypt from 'bcrypt';
+import readline from 'readline';
 
 const rl = readline.createInterface({
   input: process.stdin,

--- a/scripts/test-password.ts
+++ b/scripts/test-password.ts
@@ -1,6 +1,8 @@
-require('dotenv').config();
-// @ts-expect-error TS(2451): Cannot redeclare block-scoped variable 'bcrypt'.
-const bcrypt = require('bcrypt');
+import { config } from 'dotenv';
+import bcrypt from 'bcrypt';
+import readline from 'readline';
+
+config();
 
 async function testPassword() {
   const username = process.env.ADMIN_USERNAME;
@@ -16,7 +18,6 @@ async function testPassword() {
   console.log('='.repeat(60));
   
   // Test password
-  const readline = require('readline');
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout


### PR DESCRIPTION
The scripts were using require() syntax but the project is configured as an ES module. This was causing the npm scripts to fail.

Changes:
- debug-admin-login.ts: Convert to import/export syntax
- generate-admin-hash.ts: Convert to import/export syntax  
- test-password.ts: Convert to import/export syntax

Now users can run the debug scripts properly:
- pnpm run debug:admin
- pnpm run generate:admin
- pnpm run test:password

Fixes #199

🤖 Generated with [Claude Code](https://claude.ai/code)