### PR TITLE
fix: Resolve Render deployment build errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,9 @@
     "nodemailer": "^7.0.9",
     "pg": "^8.16.3",
     "pino": "^10.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@types/node": "^20.19.22",
+    "typescript": "^5.6.3"
   },
   "devDependencies": {
     "@types/compression": "^1.7.9",
@@ -26,12 +28,10 @@
     "@types/cors": "^2.8.19",
     "@types/dotenv": "^8.2.3",
     "@types/express": "^4.17.21",
-    "@types/node": "^20.19.22",
     "@types/nodemailer": "^7.0.2",
     "@types/pg": "^8.15.5",
     "@types/pino": "^7.0.5",
     "pino-pretty": "^13.1.2",
-    "tsx": "^4.20.6",
-    "typescript": "^5.6.3"
+    "tsx": "^4.20.6"
   }
 }

--- a/apps/web/src/components/AdminLogin.tsx
+++ b/apps/web/src/components/AdminLogin.tsx
@@ -62,7 +62,7 @@ const AdminLogin = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center p-4" style={{minHeight: '100vh', minHeight: '100dvh'}}>
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center p-4" style={{minHeight: '100dvh'}}>
       <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-8 relative" style={{maxHeight: '90vh', overflowY: 'auto'}}>
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-4">


### PR DESCRIPTION
Fixes Render deployment build failures that were preventing admin login fixes from being deployed.

## Changes

**1. Fixed TypeScript Node types issue (`apps/api/package.json`)**:
- Moved `@types/node: ^20.19.22` from `devDependencies` to `dependencies`
- Moved `typescript: ^5.6.3` from `devDependencies` to `dependencies`
- This ensures TypeScript compilation works in production builds on Render

**2. Fixed duplicate minHeight key (`apps/web/src/components/AdminLogin.tsx:65`)**:
- Removed duplicate `minHeight: '100vh'` from style object
- Kept only `minHeight: '100dvh'` for modern mobile viewport support

## Root Cause
The Render deployment was failing because:
1. **TypeScript compilation error**: `@types/node` was in `devDependencies` but needed for production builds (NODE_ENV=production skips devDependencies)
2. **Build warning**: Duplicate object keys in React component style prop

## Result
Your Render deployment should now build successfully, allowing the admin login fixes to be deployed.

Fixes #199

🤖 Generated with [Claude Code](https://claude.ai/code)