### PR TITLE
fix: Update pnpm lockfile to match package.json dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,15 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
-    devDependencies:
+      '@types/node':
+        specifier: ^20.19.22
+        version: 20.19.22
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      '@types/bcrypt':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@types/compression':
         specifier: ^1.7.9
         version: 1.8.1
@@ -127,21 +135,22 @@ importers:
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
-      '@types/dotenv':
-        specifier: ^8.2.3
-        version: 8.2.3
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23
-      '@types/node':
-        specifier: ^20.19.22
-        version: 20.19.22
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/nodemailer':
         specifier: ^7.0.2
         version: 7.0.2
       '@types/pg':
         specifier: ^8.15.5
         version: 8.15.5
+    devDependencies:
+      '@types/dotenv':
+        specifier: ^8.2.3
+        version: 8.2.3
       '@types/pino':
         specifier: ^7.0.5
         version: 7.0.5
@@ -151,9 +160,6 @@ importers:
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
-      typescript:
-        specifier: ^5.6.3
-        version: 5.9.3
 
   apps/web:
     dependencies:


### PR DESCRIPTION
Moved @types packages from devDependencies to dependencies in lockfile to match the package.json structure. This fixes the Render deployment error: 'Cannot install with frozen-lockfile because pnpm-lock.yaml is not up to date with apps/api/package.json'.

Changes:
- Moved @types/node, typescript, @types/compression, @types/cookie-parser, @types/cors, @types/express, @types/nodemailer, @types/pg from devDependencies to dependencies
- Added missing @types/bcrypt and @types/jsonwebtoken to dependencies
- This ensures TypeScript compilation works during production builds on Render

Fixes #199

Generated with [Claude Code](https://claude.ai/code)