### PR TITLE
fix: Update pnpm lockfile for apps/web deployment

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,18 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.1
+        version: 4.7.0(vite@5.4.20(@types/node@20.19.22))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.21(postcss@8.5.6)
       lucide-react:
         specifier: 0.468.0
         version: 0.468.0(react@18.3.1)
+      postcss:
+        specifier: ^8.4.47
+        version: 8.5.6
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -181,6 +190,15 @@ importers:
       react-router-dom:
         specifier: ^6.26.2
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwindcss:
+        specifier: 3.4.14
+        version: 3.4.14
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.8
+        version: 5.4.20(@types/node@20.19.22)
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -206,12 +224,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@vitejs/plugin-react':
-        specifier: ^4.3.1
-        version: 4.7.0(vite@5.4.20(@types/node@20.19.22))
-      autoprefixer:
-        specifier: ^10.4.20
-        version: 10.4.21(postcss@8.5.6)
       eslint:
         specifier: ^9.38.0
         version: 9.38.0(jiti@1.21.7)
@@ -227,21 +239,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
         version: 4.6.2(eslint@9.38.0(jiti@1.21.7))
-      postcss:
-        specifier: ^8.4.47
-        version: 8.5.6
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      tailwindcss:
-        specifier: 3.4.14
-        version: 3.4.14
-      typescript:
-        specifier: ^5.6.3
-        version: 5.9.3
-      vite:
-        specifier: ^5.4.8
-        version: 5.4.20(@types/node@20.19.22)
       vitest:
         specifier: ^2.1.3
         version: 2.1.9(@types/node@20.19.22)(jsdom@26.1.0)


### PR DESCRIPTION
Move build-essential dependencies from devDependencies to dependencies in pnpm-lock.yaml to match package.json structure:
- @vitejs/plugin-react
- autoprefixer  
- postcss
- tailwindcss
- typescript
- vite

This fixes the Render deployment error: 'Cannot install with frozen-lockfile because pnpm-lock.yaml is not up to date with apps/web/package.json'.

Fixes #199

Generated with [Claude Code](https://claude.ai/code)