### PR TITLE
fix: Remove explicit SignOptions type annotation to resolve TypeScript build error

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -72,8 +72,8 @@ router.post("/admin/login", async (req: Request, res: Response) => {
       return;
     }
 
-    // JWT signing options
-    const signOptions: SignOptions = {
+    // JWT signing options - remove explicit type annotation to let TS infer
+    const signOptions = {
       expiresIn: process.env.JWT_EXPIRES_IN || "24h",
     };
 


### PR DESCRIPTION
Fixes the TypeScript compilation error that was preventing Render deployment from building.

## Problem
The build was failing with:
```
src/routes/auth.ts(77,7): error TS2322: Type 'string' is not assignable to type 'number | StringValue | undefined'.
```

## Solution
Removed the explicit `SignOptions` type annotation and let TypeScript infer the correct type for the `signOptions` object. This allows the JWT library to accept the string value for `expiresIn` without type conflicts.

## Changes
- `apps/api/src/routes/auth.ts`: Removed explicit SignOptions type annotation

## Result
- TypeScript compilation now succeeds
- Admin login functionality remains unchanged
- Render deployment should build successfully

Fixes #199

🤖 Generated with [Claude Code](https://claude.ai/code)