### PR TITLE
fix: Resolve TypeScript JWT SignOptions type compatibility error

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -72,16 +72,13 @@ router.post("/admin/login", async (req: Request, res: Response) => {
       return;
     }
 
-    // JWT signing options - remove explicit type annotation to let TS infer
-    const signOptions = {
-      expiresIn: process.env.JWT_EXPIRES_IN || "24h",
-    };
-
-    // 👇 Fix 2: cast JWT_SECRET as Secret when calling jwt.sign
+    // Create JWT token with proper type handling
     const token = jwt.sign(
       { username, role: "admin" },
       JWT_SECRET as Secret,
-      signOptions
+      {
+        expiresIn: process.env.JWT_EXPIRES_IN || "24h",
+      } as SignOptions
     );
 
     res.cookie("adminToken", token, {
@@ -96,7 +93,7 @@ router.post("/admin/login", async (req: Request, res: Response) => {
     res.status(200).json({
       success: true,
       message: "Login successful",
-      expiresIn: signOptions.expiresIn,
+      expiresIn: process.env.JWT_EXPIRES_IN || "24h",
     });
     return;
   } catch (error) {


### PR DESCRIPTION
Fixes the Render deployment TypeScript build error that was preventing admin login functionality from being deployed.

## Problem
The build was failing with:
```
src/routes/auth.ts(81,23): error TS2769: No overload matches this call
Argument of type '{ expiresIn: string; }' is not assignable to parameter of type 'SignOptions'
```

## Root Cause
The `SignOptions` interface requires specific types for `expiresIn`, but our environment variable string didn't satisfy the strict union type `number | StringValue | undefined`.

## Solution
- Moved JWT options inline with explicit `as SignOptions` type assertion
- Removed the separate `signOptions` variable that was causing type conflicts
- Updated the response to reference the environment variable directly

## Result
- ✅ TypeScript compilation error resolved
- ✅ JWT token generation works correctly
- ✅ Render deployment should now build successfully
- ✅ Admin login functionality preserved

Fixes #199

🤖 Generated with [Claude Code](https://claude.ai/code)