### PR TITLE
Fix TypeScript compilation error in res.end() method override

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -95,25 +95,12 @@ const debugResponse = (req: Request, res: Response, next: express.NextFunction) 
 
   // Override res.end to catch any direct response endings
   const originalEnd = res.end.bind(res);
-  res.end = function(chunk?: any, encoding?: BufferEncoding, cb?: () => void) {
-    console.log(`🔍 END: res.end called with chunk:`, chunk);
+  res.end = function(...args: any[]) {
+    console.log(`🔍 END: res.end called with args:`, args);
     logResponseState("before end()");
 
-    // Handle the different overloads of res.end()
-    let result;
-    if (typeof encoding === 'function') {
-      // res.end(chunk, callback)
-      result = originalEnd(chunk, encoding);
-    } else if (encoding !== undefined && cb !== undefined) {
-      // res.end(chunk, encoding, callback)
-      result = originalEnd(chunk, encoding, cb);
-    } else if (encoding !== undefined) {
-      // res.end(chunk, encoding)
-      result = originalEnd(chunk, encoding);
-    } else {
-      // res.end(chunk)
-      result = originalEnd(chunk);
-    }
+    // Call original end with all arguments
+    const result = originalEnd.apply(res, args);
 
     console.log(`🔍 END: res.end execution completed`);
     logResponseState("after end()");


### PR DESCRIPTION
Fixes TypeScript compilation error that was preventing Render deployment

- Replace explicit parameter handling with rest parameters and apply()
- Fixes type compatibility issues with Express Response.end() overloads
- Resolves Render deployment compilation failures

Closes #218

Generated with [Claude Code](https://claude.ai/code)