### PR TITLE
Fix CSS syntax error preventing Render deployment

### DIFF
--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -96,8 +96,6 @@
   }
 }
 
-}
-
 @supports (scrollbar-width: thin) {
   * {
     scrollbar-width: thin;        /* Firefox */


### PR DESCRIPTION
Fixes CSS syntax error that was preventing Render deployment

- Remove extra closing brace at line 99 in apps/web/src/styles/index.css
- Resolves PostCSS parser error causing Vite build to fail
- Fixes Render deployment compilation failures

Closes #218

Generated with [Claude Code](https://claude.ai/code)