### PR TITLE
fix: close unclosed @layer base block in CSS

### DIFF
--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -121,15 +121,16 @@
     box-sizing: border-box;
   }
 
-/* Screen Reader Only utility */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  /* Screen Reader Only utility */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 }


### PR DESCRIPTION
Fixes deployment issue where PostCSS was failing due to missing closing brace in apps/web/src/styles/index.css at line 117. The @layer base block was opened but never closed, causing both app/api and app/web builds to fail during deployment.

Closes #222

Generated with [Claude Code](https://claude.ai/code)