### PR TITLE
fix: resolve deployment TypeScript errors

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -95,21 +95,12 @@ const debugResponse = (req: Request, res: Response, next: express.NextFunction) 
 
   // Override res.end to catch any direct response endings
   const originalEnd = res.end.bind(res);
-  res.end = function(chunk?: any, encoding?: BufferEncoding, cb?: (() => void) | undefined) {
-    console.log(`🔍 END: res.end called with args:`, { chunk, encoding, cb: !!cb });
+  res.end = function(...args: any[]) {
+    console.log(`🔍 END: res.end called with ${args.length} args:`, args);
     logResponseState("before end()");
 
-    // Call original end with proper argument handling
-    let result;
-    if (arguments.length === 0) {
-      result = originalEnd.call(res);
-    } else if (arguments.length === 1) {
-      result = originalEnd.call(res, chunk);
-    } else if (arguments.length === 2) {
-      result = originalEnd.call(res, chunk, encoding);
-    } else {
-      result = originalEnd.call(res, chunk, encoding, cb);
-    }
+    // Call original end with all arguments
+    const result = originalEnd.apply(res, args);
 
     console.log(`🔍 END: res.end execution completed`);
     logResponseState("after end()");


### PR DESCRIPTION
Fixed TypeScript compilation errors preventing API deployment:

**Issues Fixed:**
1. CSS syntax error in `apps/web/src/styles/index.css` - missing closing brace for `@layer base` block
2. TypeScript type mismatch in `apps/api/src/routes/auth.ts` - `res.end` method override parameter conflicts

**Root Cause:**
The `res.end` override used explicit parameter types that didn't match Express's method overloads, causing TypeScript compilation to fail during deployment.

**Solution:**
- Replaced explicit parameters with rest parameters (`...args: any[]`)
- Used `.apply()` for proper argument forwarding
- Maintains all debugging functionality while avoiding type conflicts

Closes #222

🤖 Generated with [Claude Code](https://claude.ai/code)