### PR TITLE
fix: resolve TypeScript error in auth.ts res.end override

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -95,7 +95,7 @@ const debugResponse = (req: Request, res: Response, next: express.NextFunction) 
 
   // Override res.end to catch any direct response endings
   const originalEnd = res.end.bind(res);
-  res.end = function(...args: any[]) {
+  res.end = function(...args: Parameters<typeof res.end>) {
     console.log(`🔍 END: res.end called with ${args.length} args:`, args);
     logResponseState("before end()");
 


### PR DESCRIPTION
Fixes TypeScript compilation error in `src/routes/auth.ts` at line 103.

The issue was that the `res.end` method override was using `any[]` for parameter types, but TypeScript expected specific parameter types. 

Changed from:
```typescript
res.end = function(...args: any[]) {
```

To:
```typescript
res.end = function(...args: Parameters<typeof res.end>) {
```

This uses TypeScript's `Parameters` utility type to properly extract the parameter types from the original `res.end` method.

Fixes #226

Generated with [Claude Code](https://claude.ai/code)