### PR TITLE
fix: resolve admin auth TypeScript compilation errors

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -95,12 +95,21 @@ const debugResponse = (req: Request, res: Response, next: express.NextFunction) 
 
   // Override res.end to catch any direct response endings
   const originalEnd = res.end.bind(res);
-  res.end = function(...args: Parameters<typeof res.end>) {
-    console.log(`🔍 END: res.end called with ${args.length} args:`, args);
+  res.end = function(chunk?: any, encoding?: BufferEncoding, cb?: (() => void) | undefined) {
+    console.log(`🔍 END: res.end called with ${arguments.length} args:`, Array.from(arguments));
     logResponseState("before end()");
 
     // Call original end with all arguments
-    const result = originalEnd.apply(res, args);
+    let result;
+    if (arguments.length === 0) {
+      result = originalEnd();
+    } else if (arguments.length === 1) {
+      result = originalEnd(chunk);
+    } else if (arguments.length === 2) {
+      result = originalEnd(chunk, encoding);
+    } else {
+      result = originalEnd(chunk, encoding, cb);
+    }
 
     console.log(`🔍 END: res.end execution completed`);
     logResponseState("after end()");


### PR DESCRIPTION
Fixes TypeScript compilation errors in `src/routes/auth.ts` related to res.end method overrides.

This PR addresses two sequential TypeScript errors:

1. **First error (line 103):** Parameter type mismatch for res.end override
2. **Second error (line 98):** Function signature incompatible with multiple res.end overloads

## Changes

**Initial fix:**
- Changed `...args: any[]` to `...args: Parameters<typeof res.end>`

**Follow-up fix:**
- Replaced spread operator approach with explicit argument handling
- Now properly handles all res.end overloads:
  - `res.end()` - 0 args
  - `res.end(chunk)` - 1 arg
  - `res.end(chunk, encoding)` - 2 args
  - `res.end(chunk, encoding, cb)` - 3 args

## Testing
This fix addresses the specific TypeScript compilation errors without changing runtime behavior. The method overrides maintain the same debugging functionality while satisfying TypeScript's strict type checking.

Fixes #226

🤖 Generated with [Claude Code](https://claude.ai/code)