### PR TITLE
fix: resolve TypeScript res.end method override compilation errors

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -95,21 +95,12 @@ const debugResponse = (req: Request, res: Response, next: express.NextFunction) 
 
   // Override res.end to catch any direct response endings
   const originalEnd = res.end.bind(res);
-  res.end = function(chunk?: any, encoding?: BufferEncoding, cb?: (() => void) | undefined) {
+  res.end = function(...args: any[]) {
     console.log(`🔍 END: res.end called with ${arguments.length} args:`, Array.from(arguments));
     logResponseState("before end()");
 
-    // Call original end with all arguments
-    let result;
-    if (arguments.length === 0) {
-      result = originalEnd();
-    } else if (arguments.length === 1) {
-      result = originalEnd(chunk);
-    } else if (arguments.length === 2) {
-      result = originalEnd(chunk, encoding);
-    } else {
-      result = originalEnd(chunk, encoding, cb);
-    }
+    // Call original end with all arguments using apply to preserve exact argument handling
+    const result = originalEnd.apply(res, args);
 
     console.log(`🔍 END: res.end execution completed`);
     logResponseState("after end()");


### PR DESCRIPTION
Fixes TypeScript compilation errors in `src/routes/auth.ts` by simplifying the res.end method override.

## Problem
Express's `res.end` method has multiple overloads that created TypeScript signature compatibility issues when trying to use explicit parameter types.

## Solution
- Changed from explicit parameter typing to `...args: any[]`
- Use `apply()` to properly forward arguments to original method
- Maintains all debugging functionality while satisfying TypeScript
- Removes 12 lines of complex argument handling logic

## Testing
This fix addresses the specific TypeScript compilation errors without changing runtime behavior. The method override maintains the same debugging functionality while being compatible with all Express res.end overloads.

Fixes #226

🤖 Generated with [Claude Code](https://claude.ai/code)