### PR TITLE
fix: Replace unsafe TypeScript type assertions with proper types

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -34,8 +34,9 @@ const shutdown = (signal: string) => {
   }, 10_000).unref();
 };
 
-['SIGINT', 'SIGTERM'].forEach(sig => {
-  process.on(sig as NodeJS.Signals, () => shutdown(sig));
+const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+signals.forEach(sig => {
+  process.on(sig, () => shutdown(sig));
 });
 
 // Safety nets for unknown crashes

--- a/apps/api/src/services/variationAnalysis.ts
+++ b/apps/api/src/services/variationAnalysis.ts
@@ -7,6 +7,15 @@
 
 import { db } from '../lib/db.js';
 
+// Define a minimal card interface for variation analysis
+interface VariationCard {
+  treatment?: string;
+  border_color?: string;
+  frame_effect?: string;
+  finish?: string;
+  set_id?: unknown;
+}
+
 // Constants from MTG spec
 const IGNORE_FRAME_EFFECTS = [
   'legendary', 'enchantment', 'snow', 'miracle', 'boosterfun'
@@ -64,7 +73,7 @@ async function analyzeSetVariations(setId: number, gameId: number) {
       totalVariations: cards.length
     };
     
-    cards.forEach((card: Record<string, unknown>) => {
+    cards.forEach((card: VariationCard) => {
       // Collect treatment codes
       if (card.treatment) {
         analysis.treatmentCodes.add(card.treatment);
@@ -203,7 +212,7 @@ async function analyzeGameVariations(gameId: number) {
       totalCards: cards.length
     };
     
-    cards.forEach((card: Record<string, unknown>) => {
+    cards.forEach((card: VariationCard) => {
       // Track sets
       if (card.set_id) {
         analysis.sets.add(card.set_id);

--- a/apps/api/tests/e2e/checkout.flow.test.ts
+++ b/apps/api/tests/e2e/checkout.flow.test.ts
@@ -99,7 +99,7 @@ describe("Complete Checkout Flow (E2E)", () => {
       .expect(200);
 
     const updatedVariation = updatedCardRes.body.card.variations.find(
-      (v: Record<string, unknown>) => v.inventory_id === variation.inventory_id
+      (v: { inventory_id: unknown; stock: number }) => v.inventory_id === variation.inventory_id
     );
     expect(updatedVariation.stock).toBe(variation.stock - cartItem.quantity);
 
@@ -397,14 +397,14 @@ describe("Complete Checkout Flow (E2E)", () => {
         email: "customer@example.com",
         name: "Multi-item Customer"
       },
-      items: card.variations.slice(0, 2).map((v: Record<string, unknown>) => ({
+      items: card.variations.slice(0, 2).map((v: { inventory_id: unknown; price: number }) => ({
         inventory_id: v.inventory_id,
         card_id: card.id,
         card_name: card.name,
         quantity: 1,
         price: v.price
       })),
-      total: card.variations.slice(0, 2).reduce((sum: number, v: Record<string, unknown>) => sum + (v.price as number), 0)
+      total: card.variations.slice(0, 2).reduce((sum: number, v: { price: number }) => sum + v.price, 0)
     };
 
     const orderRes = await request(app)

--- a/apps/api/tests/integration/inventory.routes.test.ts
+++ b/apps/api/tests/integration/inventory.routes.test.ts
@@ -188,7 +188,7 @@ describe("GET /api/admin/inventory", () => {
       .expect(200);
 
     expect(res.body.inventory).toBeDefined();
-    res.body.inventory.forEach((item: Record<string, unknown>) => {
+    res.body.inventory.forEach((item: { card_id: number }) => {
       expect(item.card_id).toBe(1001);
     });
   });

--- a/apps/api/tests/integration/orders.routes.test.ts
+++ b/apps/api/tests/integration/orders.routes.test.ts
@@ -232,7 +232,7 @@ describe("GET /api/admin/orders", () => {
       .expect(200);
 
     expect(res.body.orders).toBeDefined();
-    res.body.orders.forEach((order: Record<string, unknown>) => {
+    res.body.orders.forEach((order: { status: string }) => {
       expect(order.status).toBe("pending");
     });
   });

--- a/apps/api/tests/integration/storefront.routes.test.ts
+++ b/apps/api/tests/integration/storefront.routes.test.ts
@@ -44,7 +44,7 @@ describe("GET /api/storefront/cards", () => {
 
     expect(res.body.cards).toBeDefined();
     // All cards should belong to game_id 1
-    res.body.cards.forEach((card: Record<string, unknown>) => {
+    res.body.cards.forEach((card: { game_id?: number; game_name?: string }) => {
       expect(card.game_id || card.game_name).toBeDefined();
     });
   });

--- a/apps/web/src/services/error/handler.ts
+++ b/apps/web/src/services/error/handler.ts
@@ -56,8 +56,8 @@ export function categorizeError(error: unknown): ErrorType {
   }
 
   // Extract status code with proper type checking
-  const errorObj = error as Record<string, unknown>;
-  const status = errorObj.status || (errorObj.response as Record<string, unknown>)?.status;
+  const errorObj = error as { status?: number; response?: { status?: number } };
+  const status = errorObj.status || errorObj.response?.status;
 
   // Authentication errors
   if (status === HTTP_STATUS.UNAUTHORIZED || status === HTTP_STATUS.FORBIDDEN) {


### PR DESCRIPTION
Resolves #270

This PR fixes multiple TypeScript type safety issues throughout the codebase:

## Issues Fixed:
- Replaced unsafe `sig as NodeJS.Signals` type assertion with proper typed array
- Eliminated dangerous `v.price as number` casting by using proper interface typing
- Added `VariationCard` interface to replace `Record<string, unknown>` 
- Replaced generic `Record<string, unknown>` with specific property interfaces in test files
- Improved error type assertions with more specific error structure

## Result:
All TypeScript problems have been fixed using proper type definitions and interfaces instead of unsafe type assertions. The codebase now has better type safety and should compile without errors.

Generated with [Claude Code](https://claude.ai/code)