### PR TITLE
fix: resolve AdminCardGrid type error with BrowseBaseCard adapter

### DIFF
--- a/apps/web/src/features/admin/components/Cards/AdminCardGrid.tsx
+++ b/apps/web/src/features/admin/components/Cards/AdminCardGrid.tsx
@@ -9,6 +9,7 @@ import { useVirtualScroll } from '@/lib/utils';
 import type { BrowseBaseCard, BrowseVariation } from '@/types';
 import { CardItem, CardSkeleton } from '@/shared/card';
 import { ChevronDown } from 'lucide-react';
+import { browseCardToCard } from '@/features/admin/utils/cardAdapters';
 
 // ============================================================================
 // TYPES
@@ -96,18 +97,21 @@ export const AdminCardGrid = ({
   // ADMIN CARD RENDERER - SPECIALIZED FOR BrowseBaseCard
   // ============================================================================
 
-  const renderAdminCard = (card: BrowseBaseCard) => {
+  const renderAdminCard = (browseCard: BrowseBaseCard) => {
+    // Convert BrowseBaseCard to Card for CardItem component
+    const card = browseCardToCard(browseCard);
+
     // For admin mode, we treat the card itself as the main entity
     // with its variations being the different card rows
     return (
       <CardItem
-        key={card.id}
+        key={browseCard.id}
         card={card}
         selectedVariationKey={null} // Not used in admin mode
         selectedVariation={null}     // Not used in admin mode
         currency={{ code: 'USD', symbol: '$', rate: 1, label: 'US Dollar' }}
         onVariationChange={() => {}} // No-op in admin mode
-        onAddToCart={() => onAddToInventory?.(card)}
+        onAddToCart={() => onAddToInventory?.(browseCard)}
         isAdminMode={true}
       />
     );

--- a/apps/web/src/features/admin/utils/cardAdapters.ts
+++ b/apps/web/src/features/admin/utils/cardAdapters.ts
@@ -1,0 +1,62 @@
+// File: apps/web/src/features/admin/utils/cardAdapters.ts
+
+import type { BrowseBaseCard, BrowseVariation, Card, CardVariation } from '@/types';
+
+/**
+ * Converts a BrowseVariation to CardVariation for display purposes
+ *
+ * BrowseVariation represents card rows with treatment/finish metadata
+ * CardVariation represents inventory entries with quality/foil/language options
+ */
+function browseVariationToCardVariation(variation: BrowseVariation): CardVariation {
+  return {
+    inventory_id: variation.id, // Use card row ID as inventory_id
+    quality: 'Near Mint', // Default quality for admin display
+    foil_type: variation.finish === 'foil' ? 'Foil' : 'Regular', // Map finish to foil_type
+    language: 'English', // Default language for admin display
+    price: variation.price || 0,
+    stock: variation.in_stock || 0, // Map in_stock to stock
+    variation_key: `Near Mint-${variation.finish === 'foil' ? 'Foil' : 'Regular'}-English`,
+
+    // Include backward compatibility fields
+    finish: variation.finish,
+    treatment: variation.treatment,
+  };
+}
+
+/**
+ * Converts a BrowseBaseCard to Card for display in CardItem components
+ *
+ * BrowseBaseCard is used in admin context with BrowseVariation[] (card rows)
+ * Card is expected by CardItem component with CardVariation[] (inventory entries)
+ */
+export function browseCardToCard(browseCard: BrowseBaseCard): Card {
+  return {
+    // Core identification - direct mapping
+    id: browseCard.id,
+    name: browseCard.name,
+    sku: browseCard.sku || `browse-${browseCard.id}`,
+    card_number: browseCard.card_number || '',
+    set_name: browseCard.set_name || '',
+    game_name: browseCard.game_name || '',
+    game_id: browseCard.game_id,
+    set_id: browseCard.set_id,
+    rarity: browseCard.rarity,
+    image_url: browseCard.image_url,
+
+    // Variation metadata - take from first variation if available
+    treatment: browseCard.variations[0]?.treatment || browseCard.treatment,
+    border_color: browseCard.variations[0]?.border_color || browseCard.border_color,
+    finish: browseCard.variations[0]?.finish || browseCard.finish,
+    frame_effect: browseCard.variations[0]?.frame_effect || browseCard.frame_effect,
+    promo_type: browseCard.variations[0]?.promo_type || browseCard.promo_type,
+
+    // Inventory aggregates - direct mapping
+    total_stock: browseCard.total_stock,
+    variation_count: browseCard.variation_count,
+    has_inventory: browseCard.total_stock > 0,
+
+    // Transform variations array
+    variations: browseCard.variations.map(browseVariationToCardVariation),
+  };
+}


### PR DESCRIPTION
Resolves #295

## Summary
- Create cardAdapters utility to convert BrowseBaseCard to Card type
- Map BrowseVariation to CardVariation for CardItem compatibility
- Update AdminCardGrid to use adapter before passing to CardItem
- Maintains existing CardItem component reuse as recommended in Option A

## Implementation

Implemented Option A from the issue description:
1. Created `apps/web/src/features/admin/utils/cardAdapters.ts` with type conversion functions
2. Updated `AdminCardGrid` to transform `BrowseBaseCard` before passing to `CardItem`

## Key Mappings
- `BrowseVariation.in_stock` → `CardVariation.stock`
- `BrowseVariation.finish` → `CardVariation.foil_type`
- `BrowseVariation.id` → `CardVariation.inventory_id`
- Added required fields: `quality`, `language`, `variation_key`

🤖 Generated with [Claude Code](https://claude.ai/code)