### PR TITLE
fix: ensure card variations are returned as complete groups

### DIFF
--- a/apps/web/src/features/admin/components/Cards/CardsTab.tsx
+++ b/apps/web/src/features/admin/components/Cards/CardsTab.tsx
@@ -561,10 +561,18 @@ const UnifiedCardsTab: React.FC<UnifiedCardsTabProps> = ({ mode = 'all' }) => {
             <span> unique cards</span>
             {' • '}
             <span className="font-semibold text-slate-900">{displayCards.length}</span>
-            <span> displayed</span>
-            {totalCardCount > 1000 && (
+            <span> total variations</span>
+            {displayCards.length > uniqueCards && (
+              <span className="text-xs text-slate-500 ml-1">
+                (~{Math.round(displayCards.length / uniqueCards * 10) / 10} variations per card)
+              </span>
+            )}
+            {totalCardCount > uniqueCards && (
               <span className="text-amber-600 ml-2">
-                (of {totalCardCount} total)
+                Showing {uniqueCards} of {Math.ceil(totalCardCount / (displayCards.length / uniqueCards || 1))} cards
+                <span className="text-xs block text-amber-500">
+                  (all variations included for shown cards)
+                </span>
               </span>
             )}
             {isInventoryMode && (


### PR DESCRIPTION
Fixes the critical issue where card variations were being split across the LIMIT 1000 boundary, leading to incomplete variation sets.

## Changes
- Replace direct LIMIT with two-phase CTE query in cards.ts
- Phase 1: Get unique card identities with limit applied
- Phase 2: Fetch ALL variations for those card identities
- Update frontend stats to show "total variations" vs "displayed"
- Add clearer warning messages about complete variation sets

Fixes #304

Generated with [Claude Code](https://claude.ai/code)