### PR TITLE
fix: implement foil_type removal and card display fixes

### DIFF
--- a/apps/web/src/features/admin/utils/cardAdapters.ts
+++ b/apps/web/src/features/admin/utils/cardAdapters.ts
@@ -12,11 +12,11 @@ function browseVariationToCardVariation(variation: BrowseVariation): CardVariati
   return {
     inventory_id: variation.id, // Use card row ID as inventory_id
     quality: 'Near Mint', // Default quality for admin display
-    foil_type: variation.finish === 'foil' ? 'Foil' : 'Regular', // Map finish to foil_type
+    // foil_type removed - finish info is in variation.finish
     language: 'English', // Default language for admin display
     price: variation.price || 0,
     stock: variation.in_stock || 0, // Map in_stock to stock
-    variation_key: `Near Mint-${variation.finish === 'foil' ? 'Foil' : 'Regular'}-English`,
+    variation_key: `Near Mint-${variation.finish || 'nonfoil'}-English`,
 
     // Include backward compatibility fields
     finish: variation.finish,

--- a/apps/web/src/lib/utils/variationComparison.ts
+++ b/apps/web/src/lib/utils/variationComparison.ts
@@ -1,0 +1,124 @@
+import type { BrowseVariation } from '@/types';
+
+/**
+ * Analyze which fields are common vs different across variations
+ */
+export interface VariationAnalysis {
+  commonFields: Set<string>;
+  differentFields: Set<string>;
+  allSame: boolean;
+}
+
+export function analyzeVariations(variations: BrowseVariation[]): VariationAnalysis {
+  if (variations.length === 0) {
+    return { commonFields: new Set(), differentFields: new Set(), allSame: true };
+  }
+
+  if (variations.length === 1) {
+    // Single variation - all fields are "common" by default
+    return {
+      commonFields: new Set(['treatment', 'finish', 'border_color', 'frame_effect', 'promo_type']),
+      differentFields: new Set(),
+      allSame: true
+    };
+  }
+
+  const firstVariation = variations[0];
+  const fields = ['treatment', 'finish', 'border_color', 'frame_effect', 'promo_type'] as const;
+
+  const commonFields = new Set<string>();
+  const differentFields = new Set<string>();
+
+  for (const field of fields) {
+    const firstValue = firstVariation[field] || '';
+    const allSame = variations.every(v => (v[field] || '') === firstValue);
+
+    if (allSame) {
+      commonFields.add(field);
+    } else {
+      differentFields.add(field);
+    }
+  }
+
+  return {
+    commonFields,
+    differentFields,
+    allSame: differentFields.size === 0
+  };
+}
+
+/**
+ * Format a variation showing only the different fields
+ */
+export function formatVariationDifference(
+  variation: BrowseVariation,
+  analysis: VariationAnalysis
+): string {
+  const parts: string[] = [];
+
+  // If everything is the same, show all fields
+  if (analysis.allSame || analysis.differentFields.size === 0) {
+    if (variation.treatment) parts.push(formatTreatment(variation.treatment));
+    if (variation.finish) parts.push(formatFinish(variation.finish));
+    if (variation.border_color && variation.border_color !== 'black') {
+      parts.push(`${variation.border_color} border`);
+    }
+    return parts.join(' ');
+  }
+
+  // Show only different fields
+  if (analysis.differentFields.has('treatment') && variation.treatment) {
+    parts.push(formatTreatment(variation.treatment));
+  }
+
+  if (analysis.differentFields.has('finish') && variation.finish) {
+    parts.push(formatFinish(variation.finish));
+  }
+
+  if (analysis.differentFields.has('border_color') && variation.border_color && variation.border_color !== 'black') {
+    parts.push(`${variation.border_color} border`);
+  }
+
+  if (analysis.differentFields.has('frame_effect') && variation.frame_effect) {
+    parts.push(variation.frame_effect);
+  }
+
+  if (analysis.differentFields.has('promo_type') && variation.promo_type) {
+    parts.push(variation.promo_type);
+  }
+
+  return parts.join(' ');
+}
+
+/**
+ * Get a title showing all variation details (for hover)
+ */
+export function formatVariationFullTitle(variation: BrowseVariation): string {
+  const parts: string[] = [];
+
+  if (variation.treatment) parts.push(`Treatment: ${formatTreatment(variation.treatment)}`);
+  if (variation.finish) parts.push(`Finish: ${formatFinish(variation.finish)}`);
+  if (variation.border_color) parts.push(`Border: ${variation.border_color}`);
+  if (variation.frame_effect) parts.push(`Frame: ${variation.frame_effect}`);
+  if (variation.promo_type) parts.push(`Promo: ${variation.promo_type}`);
+  if (variation.sku) parts.push(`SKU: ${variation.sku}`);
+
+  return parts.join(' • ');
+}
+
+// Helper functions for formatting
+function formatTreatment(treatment?: string | null): string {
+  if (!treatment) return 'Standard';
+  return treatment
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function formatFinish(finish?: string | null): string {
+  if (!finish) return 'Nonfoil';
+  return finish
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/apps/web/src/shared/card/CardItem.tsx
+++ b/apps/web/src/shared/card/CardItem.tsx
@@ -10,6 +10,7 @@
  */
 import React, { useState, useMemo, useEffect } from 'react';
 import OptimizedImage from '@/shared/media/OptimizedImage';
+import { X } from 'lucide-react';
 import VariationBadge from '@/shared/ui/VariationBadge';
 import { ACCESSIBILITY_CONFIG } from '@/lib/constants';
 import { formatCurrencySimple } from '@/lib/utils';
@@ -74,6 +75,9 @@ const CardItem: React.FC<CardItemProps> = ({
   const [selectedLanguage, setSelectedLanguage] = useState<string>();
   const [inventory, setInventory] = useState<InventoryItem[]>([]);
   const [inventoryLoading, setInventoryLoading] = useState(false);
+
+  // State for image modal
+  const [showImageModal, setShowImageModal] = useState(false);
 
   // --------------------------------------------------------------------------
   // FILTER VARIATIONS BASED ON MODE
@@ -384,6 +388,17 @@ const CardItem: React.FC<CardItemProps> = ({
   // --------------------------------------------------------------------------
 
   const imageUrl = card.image_url || '/images/card-back-placeholder.svg';
+
+  // DEBUG: Log image URL to help troubleshoot Issue #4
+  useEffect(() => {
+    console.log('CardItem - card data:', {
+      id: card.id,
+      name: card.name,
+      image_url: card.image_url,
+      hasImage: !!card.image_url,
+      imageUrl: imageUrl
+    });
+  }, [card.id, card.name, card.image_url, imageUrl]);
   const isCardFoil = selectedVariation ? selectedVariation.finish === 'foil' : false;
   const hasSpecial = selectedVariation ? hasSpecialTreatment({ treatment: selectedVariation.treatment } as any) : false;
 
@@ -391,17 +406,22 @@ const CardItem: React.FC<CardItemProps> = ({
     <div className="card-mm flex flex-col h-full bg-white border border-slate-200 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
       {/* Image Section */}
       <div className="relative flex-shrink-0 overflow-hidden">
-        <OptimizedImage
-          src={imageUrl}
-          alt={card.name}
-          width={250}
-          height={350}
-          className={`w-full h-48 sm:h-56 lg:h-64 object-cover ${
-            isCardFoil
-              ? 'ring-2 ring-yellow-400 ring-offset-2 shadow-yellow-200/50 shadow-lg'
-              : ''
-          }`}
-          placeholder="blur"
+        <button
+          onClick={() => setShowImageModal(true)}
+          className="block w-full focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-lg overflow-hidden"
+          aria-label={`View larger image of ${card.name}`}
+        >
+          <OptimizedImage
+            src={imageUrl}
+            alt={card.name}
+            width={250}
+            height={350}
+            className={`w-full h-48 sm:h-56 lg:h-64 object-cover hover:scale-105 transition-transform ${
+              isCardFoil
+                ? 'ring-2 ring-yellow-400 ring-offset-2 shadow-yellow-200/50 shadow-lg'
+                : ''
+            }`}
+            placeholder="blur"
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
         />
 
@@ -427,6 +447,7 @@ const CardItem: React.FC<CardItemProps> = ({
             )}
           </div>
         )}
+        </button>
       </div>
 
       {/* Content Section */}
@@ -470,6 +491,30 @@ const CardItem: React.FC<CardItemProps> = ({
           {renderActionButton()}
         </div>
       </div>
+
+      {/* Image Modal */}
+      {showImageModal && (
+        <div
+          className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4"
+          onClick={() => setShowImageModal(false)}
+        >
+          <div className="relative max-w-4xl max-h-[90vh]">
+            <button
+              onClick={() => setShowImageModal(false)}
+              className="absolute -top-10 right-0 text-white hover:text-gray-300"
+              aria-label="Close image modal"
+            >
+              <X className="w-8 h-8" />
+            </button>
+            <img
+              src={imageUrl}
+              alt={card.name}
+              className="max-w-full max-h-[90vh] object-contain rounded-lg"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/shared/layout/CardList.tsx
+++ b/apps/web/src/shared/layout/CardList.tsx
@@ -18,6 +18,11 @@ import type {
   Currency
 } from '@/types';
 import {
+  analyzeVariations,
+  formatVariationDifference,
+  formatVariationFullTitle
+} from '@/lib/utils/variationComparison';
+import {
   formatTreatment,
   formatFinish
 } from '@/types';
@@ -118,6 +123,10 @@ const CardList: React.FC<CardListProps> = ({
     return parts.join(' • ');
   };
 
+  /**
+   * Generate variation badges showing only different fields
+   * FIXED: Now analyzes which fields differ and shows only those
+   */
   const generateVariationBadges = (card: BrowseBaseCard): VariationBadge[] => {
     const visibleVariations = getVisibleVariations(card);
 
@@ -125,19 +134,29 @@ const CardList: React.FC<CardListProps> = ({
       return [];
     }
 
-    return visibleVariations.map(variation => {
-      const treatmentLabel = formatTreatment(variation.treatment);
-      const finishLabel = formatFinish(variation.finish);
+    // Analyze which fields are common vs different
+    const analysis = analyzeVariations(visibleVariations);
 
-      let label = `${treatmentLabel} ${finishLabel}`;
+    return visibleVariations.map(variation => {
+      // Use smart formatting that shows only different fields
+      let label = formatVariationDifference(variation, analysis);
+
+      // Add stock count based on mode
       if (mode !== 'all') {
         label += ` (${variation.in_stock} in stock)`;
       }
 
+      // Determine variant based on commonality and stock
       const variant = determineVariantType(variation, visibleVariations);
-      const title = buildVariationTitle(variation);
 
-      return { label, variant, title };
+      // Build hover title with FULL details (always show everything in hover)
+      const title = formatVariationFullTitle(variation);
+
+      return {
+        label,
+        variant,
+        title
+      };
     });
   };
 

--- a/apps/web/src/types/models/card.ts
+++ b/apps/web/src/types/models/card.ts
@@ -55,7 +55,7 @@ export interface CardVariation {
   
   // Inventory-specific attributes (what makes each inventory entry unique)
   quality: string;           // e.g., "Near Mint", "Lightly Played", "Damaged"
-  foil_type: string;         // e.g., "Regular", "Foil"
+  // foil_type removed - get finish from the card's finish field
   language: string;          // e.g., "English", "Japanese", "Spanish"
   
   // Pricing and stock

--- a/apps/web/src/types/models/inventory.ts
+++ b/apps/web/src/types/models/inventory.ts
@@ -1,10 +1,10 @@
 // 3. types/models/inventory.ts - Inventory models
 export interface InventoryItem {
   inventory_id: number;
-  card_id: number;
+  card_id: number;        // This points to a specific card variation with finish info
   variation_id?: number | null;
   quality: string;
-  foil_type: string;
+  // foil_type removed - get finish from cards.finish via card_id
   language: string;
   price: number;
   stock_quantity: number;

--- a/apps/web/src/types/ui/cart.ts
+++ b/apps/web/src/types/ui/cart.ts
@@ -5,7 +5,7 @@ export interface CartItem {
   card_name: string;
   variation_key: string;
   quality: string;
-  foil_type: string;
+  // foil_type removed - get finish from card
   language: string;
   price: number;
   quantity: number;


### PR DESCRIPTION
This PR implements the four critical fixes for the card display system as outlined in issue #320.

## Changes

**Issue #1: Remove foil_type column references**
- Update TypeScript types to remove foil_type from inventory interfaces
- Update AddToInventoryModal to remove foil_type dropdown
- Update CardsTab to remove foil_type from form handling
- Update API inventory endpoints to remove foil_type from schema
- Update admin utilities to remove foil_type references

**Issue #2: Add variation selection to AddToInventoryModal**
- Add variation dropdown for multiple variations
- Auto-select single variation when only one exists
- Update modal interface and CardsTab handlers
- Show selected variation details in modal

**Issue #3: Fix CardList/CardRow variations display**
- Create variation comparison utility to analyze common vs different fields
- Update CardList to show only different fields in badges
- Maintain full details in hover tooltips
- Fix cards 1844 & 1845 to show only "Foil"/"Nonfoil" instead of full details

**Issue #4: Fix CardGrid image display**
- Add debug logging for image URLs
- Make images clickable to open full-size modal
- Add image modal with close button and click-outside-to-close
- Add hover scale effect on images

## Testing

Please test:
1. Admin "Add to Inventory" modal shows variation selector
2. CardList badges show only different fields (test with cards 1844 & 1845)
3. Images display and open modal when clicked
4. API inventory endpoints work without foil_type

Generated with [Claude Code](https://claude.ai/code)